### PR TITLE
Feature/eeprom mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ install: $(BIN_NAME)
 	$(MAKE) -C adc/injection install
 	install -m 0644 board/wb_env.sh $(DESTDIR)/etc/wb_env.sh
 	install -m 0755 board/wb-gen-serial $(DESTDIR)/$(prefix)/bin/wb-gen-serial
+	install -m 0755 board/wb-set-mac $(DESTDIR)/$(prefix)/bin/wb-set-mac
 
 	install -m 0755 adc/wb-adc-get-value $(DESTDIR)/$(prefix)/bin/wb-adc-get-value
 	install -m 0755 adc/wb-adc-read-channel $(DESTDIR)/$(prefix)/bin/wb-adc-read-channel

--- a/board/wb-gen-serial
+++ b/board/wb-gen-serial
@@ -19,7 +19,7 @@ FALLBACK_SEED_FILE = "/var/lib/wirenboard/serial-seed"
 MAC_PREFIX = "00:86"
 
 # Serial generator revision == fisrt symbol in serial number starting from A
-GEN_REVISION = 1
+GEN_REVISION = 0
 
 
 def _get_imei():
@@ -71,7 +71,7 @@ def _get_serial_2():
 
     mmc_serial = str(get_mmc_serial())
 
-    eeprom_serial = str(get_eeprom_serial())
+    eeprom_serial = get_eeprom_serial() or ""
 
     seed_string = str(imei) + cpuinfo_serial + mmc_serial + eeprom_serial
 

--- a/board/wb-gen-serial
+++ b/board/wb-gen-serial
@@ -9,7 +9,7 @@ import string
 
 sys.path.insert(0, "/usr/lib/wb-test-suite/common/")
 
-from wb_common.uid import get_cpuinfo_serial, get_mmc_serial
+from wb_common.uid import get_cpuinfo_serial, get_mmc_serial, get_eeprom_serial
 from wb_common import gsm, wifi
 
 # Filename for random generated serial number seed
@@ -19,7 +19,7 @@ FALLBACK_SEED_FILE = "/var/lib/wirenboard/serial-seed"
 MAC_PREFIX = "00:86"
 
 # Serial generator revision == fisrt symbol in serial number starting from A
-GEN_REVISION = 0
+GEN_REVISION = 1
 
 
 def _get_imei():
@@ -71,7 +71,9 @@ def _get_serial_2():
 
     mmc_serial = str(get_mmc_serial())
 
-    seed_string = str(imei) + cpuinfo_serial + mmc_serial
+    eeprom_serial = str(get_eeprom_serial())
+
+    seed_string = str(imei) + cpuinfo_serial + mmc_serial + eeprom_serial
 
     # Generate random serial number if no seed is presented
     if len(seed_string) == 0:
@@ -176,6 +178,13 @@ def _get_eth_mac_v2(iface = 0):
 
     return MAC_PREFIX + ":" + third_octet + mac_suffix
 
+def _get_mac_eeprom(iface = 0):
+    eeprom_mac = get_eeprom_serial(iface)
+
+    if eeprom_mac:
+        return ":".join([eeprom_mac[i:i+2] for i in xrange(0, len(eeprom_mac), 2)])
+    else:
+        return ""
 
 def _get_mac_1_wifi():
     wifi_mac = wifi.get_wlan_mac()
@@ -239,7 +248,7 @@ def _get_mac_1(mac_type):
 
 def get_mac(mac_type="best", version=2, iface=0):
     if version == 2:
-        return _get_eth_mac_v2(iface)
+        return _get_mac_eeprom(iface) or _get_eth_mac_v2(iface)
     else:
         return _get_mac_1(mac_type)
 

--- a/board/wb-set-mac
+++ b/board/wb-set-mac
@@ -1,0 +1,28 @@
+#!/bin/bash
+IFACE=${IFACE:-$1}
+[[ -n "$IFACE" ]] || {
+	echo "IFACE is unset"
+	exit 1
+}
+
+[[ -z "$WB_VERSION" ]] && . /etc/wb_env.sh
+
+set_saved_mac() {
+	local saved_mac="/var/lib/wirenboard/${IFACE}_mac.conf"
+	[[ -e "$saved_mac" ]] &&
+		ifconfig $IFACE hw ether $(cat "$saved_mac") || true
+}
+
+case "$WB_VERSION" in
+	"60" | "61" )
+		# If random MAC is used (i.e. not set in DT by U-Boot or manually
+		# configured), fallback to the usual way. Otherwise, do nothing.
+		addr_type=$(cat "/sys/class/net/$IFACE/addr_assign_type")
+		[[ "$addr_type" == 1 ]] && set_saved_mac
+		;;
+
+	*)
+		set_saved_mac
+		;;
+esac
+

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (1.71) stable; urgency=medium
+
+  * add support for mac in eeprom
+
+ -- Alexey Ignatov <lexszero@gmail.com>  Sat, 22 Apr 2017 08:13:06 +0300
+
 wb-utils (1.70.5) stable; urgency=medium
 
   * fix gsm-rtc read/restore_time

--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Build-Depends: debhelper (>= 9), pkg-config
 
 Package: wb-utils
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, u-boot-tools (>= 2015.07+wb-3), inotify-tools, pv, nginx-extras, python-wb-common (>= 1.1), wb-configs (>=1.69.4)
+Depends: ${shlibs:Depends}, ${misc:Depends}, u-boot-tools (>= 2015.07+wb-3), inotify-tools, pv, nginx-extras, python-wb-common (>= 1.3.2), wb-configs (>=1.69.4)
 Conflicts: wb-configs (<= 1.68)
 Description: Wiren Board command-line utils


### PR DESCRIPTION
- Отдельный скрипт для выставления MAC интерфейсов в зависимости от того, нужно ли это делать: на WB6 с EEPROM - не нужно, фоллбэк - старое поведение.
- При наличии EEPROM, MAC из нее используется при генерации серийника. Нужен wb-common который умеет его читать (прописана зависимость).