### PR TITLE
Fix SSH keys generation

### DIFF
--- a/board/prepare.init
+++ b/board/prepare.init
@@ -331,27 +331,25 @@ wb_firstboot()
     wb_fix_macs
     wb_fix_short_sn
 
-    [[ ! -h /etc/ssh && -d /etc/ssh ]] && {
-        log_action_msg "Generating SSH host keys"
-        for keytype in ecdsa dsa rsa; do
-            log_action_begin_msg "  $keytype"
-            local keyfile=/etc/ssh_host_${keytype}_key
-            [[ -n "$data_mounted" && -e "/mnt/data/$keyfile" ]] &&
-            cp "/mnt/data/${keyfile}" "$keyfile" 2>/dev/null &&
-            log_action_cont_msg "from shared partition" &&
-            log_action_end_msg $? \
-            || {
-                [[ -f /etc/ssh/ssh_host_${keytype}_key ]] && {
-                    log_action_cont_msg " already present, keep it"
-                    log_action_end_msg $? || return $?
-                } || {
-                    yes | ssh-keygen -f /etc/ssh/ssh_host_${keytype}_key -N '' -t ${keytype} >/dev/null
-                    log_end_msg $? || return $?
-                }
+    log_action_msg "Generating SSH host keys if necessary"
+    for keytype in ecdsa dsa rsa; do
+        log_action_begin_msg "  $keytype"
+        local keyfile=/etc/ssh_host_${keytype}_key
+        [[ -n "$data_mounted" && -e "/mnt/data/$keyfile" ]] &&
+        cp "/mnt/data/${keyfile}" "$keyfile" 2>/dev/null &&
+        log_action_cont_msg "from shared partition" &&
+        log_action_end_msg $? \
+        || {
+            [[ -f /etc/ssh/ssh_host_${keytype}_key ]] && {
+                log_action_cont_msg " already present, keep it"
+                log_action_end_msg $? || return $?
+            } || {
+                yes | ssh-keygen -f /etc/ssh/ssh_host_${keytype}_key -N '' -t ${keytype} >/dev/null
+                log_end_msg $? || return $?
             }
+        }
 
-        done
-    }
+    done
 
     touch $FIRSTBOOT_FLAG
     sync

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (1.75.5) stable; urgency=critical
+
+  * Fix: generate SSH keys even if the directory is symlinked
+
+ -- Nikita Maslov <n.maslov@contactless.ru>  Fri, 29 Jun 2018 16:01:53 +0300
+
 wb-utils (1.75.4) stable; urgency=critical
 
   * Fix: disable /mnt/data formatting on hard reboot


### PR DESCRIPTION
This problem is caused by wb-configs update - now /etc/ssh is changed to symlink earlier than wb-prepare starts. This breaks new images (FIT update from older images without factory reset works though).