### PR TITLE
ignore gpiochips without of_node/phandle

### DIFF
--- a/board/of.sh
+++ b/board/of.sh
@@ -142,15 +142,19 @@ of_get_prop_auto() {
 
 of_find_gpiochips() {
 	for gpiochip in /sys/class/gpio/gpiochip*; do
-		phandle=$(bin2ulong < "$gpiochip/device/of_node/phandle")
-		OF_GPIOCHIPS[$phandle]="$(cat "$gpiochip/base")"
+		if [[ -f "$gpiochip/device/of_node/phandle" ]]; then
+			phandle=$(bin2ulong < "$gpiochip/device/of_node/phandle")
+			OF_GPIOCHIPS[$phandle]="$(cat "$gpiochip/base")"
+		fi
 	done
 }
 
 of_find_iio_dev_links() {
 	for iiodevice in /sys/bus/iio/devices/iio\:device*; do
-		phandle=$(bin2ulong < "$iiodevice/of_node/phandle")
-		OF_IIODEV_LINKS[$phandle]="$(readlink "$iiodevice")"
+		if [[ -f "$iiodevice/of_node/phandle" ]]; then
+			phandle=$(bin2ulong < "$iiodevice/of_node/phandle")
+			OF_IIODEV_LINKS[$phandle]="$(readlink "$iiodevice")"
+		fi
 	done
 }
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (2.1.2) stable; urgency=medium
+
+  * fix crash in gpiochip discovery when there are gpiochips added by hwconf-manager
+
+ -- Evgeny Boger <boger@contactless.ru>  Tue, 08 Jan 2019 17:40:08 +0300
+
 wb-utils (2.1.1) stable; urgency=medium
 
   * change u-boot-tools package name in depends


### PR DESCRIPTION
when building phandle to gpiochip map at runtime