### PR TITLE
Feature/sim7000e fix

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-utils (2.1.3) stable; urgency=medium
 
-  * handle auto bd synchronization in sim7300e modems
+  * handle auto bd synchronization in sim7000e modems
 
  -- Vladimir Romanov <v.romanov@contactless.ru>  Tue, 28 Feb 2019 20:43:08 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (2.1.3) stable; urgency=medium
+
+  * handle auto bd synchronization in sim7300e modems
+
+ -- Vladimir Romanov <v.romanov@contactless.ru>  Tue, 28 Feb 2019 20:43:08 +0300
+
 wb-utils (2.1.2) stable; urgency=medium
 
   * fix crash in gpiochip discovery when there are gpiochips added by hwconf-manager

--- a/gsm/wb-gsm-common.sh
+++ b/gsm/wb-gsm-common.sh
@@ -32,12 +32,25 @@ function get_model() {
 }
 
 
+function is_7000e() {
+    #NB-IOT modem
+    OVERLAY_FNAME='/proc/device-tree/wirenboard/overlays'
+    SEARCH_PATTERN='sim7000e'
+    ret="grep -i $SEARCH_PATTERN $OVERLAY_FNAME"
+    [[ $ret ]]
+}
+
+
 function synchronize_bd() {
-    tries=10
-    for (( i=0; i<=$tries; i++ ))
-    do
-    	echo -e "AT\r\n" > $PORT
-    done
+    if is_7000e; then
+        tries=10
+        for (( i=0; i<=$tries; i++ ))
+        do
+    	    echo -e "AT\r\n" > $PORT
+        done
+    else
+        echo  -e "AAAAAAAAAAAAAAAAAAAT\r\n" > $PORT
+    fi
 }
 
 
@@ -45,6 +58,7 @@ function is_neoway_m660a() {
     MODEL=`get_model`
     [[ "$MODEL" == "M660A" ]]
 }
+
 
 function gsm_init() {
     if [[ -z "${WB_GSM_POWER_TYPE}" ]] || [[ "$WB_GSM_POWER_TYPE" = "0" ]]; then
@@ -167,6 +181,7 @@ function init_baud() {
     set_speed 9600
     if [[ $(_try_set_baud) == 0 ]] ; then
         # connection at the lower baud rate succeded, not set the default baudrate
+        set_speed
         return
     fi
     debug "ERROR: couldn't establish connection with modem"


### PR DESCRIPTION
Проблема: в контроллерах с NB-IOT модемом генерируется неправильный серийник (без учёта imei модема).
Причина: в sim7000e автоопределение BD. У нас прописано посылать в порт "AAAAAAAAAT" для определения BD, но с sim7000e это не работает. Нужно несколько раз послать "AT".
Решение: смотрим в оверлеи: если есть sim7000e - шлём 10 раз "AT\r\n"; если нет - всё, как раньше.
Проверил на sim800 с оверлеями/без; на sim5300e с оверлеями/без; на sim7000e