### PR TITLE
Feature/wb67

### DIFF
--- a/board/wb-gen-serial
+++ b/board/wb-gen-serial
@@ -69,11 +69,8 @@ def random_word(length):
 
 def dt_is_compatible(compatible_str):
     node_fname = '/proc/device-tree/compatible'
-    try:
-        compatible_with = open(node_fname).read()
-        return True if compatible_str in compatible_with else False
-    except IOError:
-        return False
+    compatible_with = open(node_fname).read()
+    return (compatible_str in compatible_with)
 
 
 def _get_serial_2():
@@ -145,7 +142,7 @@ def _get_serial_1():
         else:
             imei = gsm.gsm_get_imei()
             # print "imei=%s" % imei
-    
+
     wifi_mac = wifi.get_wlan_mac()
 
     cpuinfo_serial = str(get_cpuinfo_serial())
@@ -286,7 +283,7 @@ def main():
                        action="store", type=int, nargs="?",
                        choices=[0,1],
                        dest="mode_eth_mac", const=0, default=0)
-    
+
     parser.add_argument("-v", "--version", help="Select version of serial number (1 - old, 2 - new), default - 2",
                         type=int, default=2, choices=[1, 2])
 

--- a/board/wb-gen-serial
+++ b/board/wb-gen-serial
@@ -21,6 +21,9 @@ MAC_PREFIX = "00:86"
 # Serial generator revision == fisrt symbol in serial number starting from A
 GEN_REVISION = 0
 
+# A workaround to remove modem IMEI from generating SN on specific boards
+DT_MODEM_IS_MODULE = 'contactless,imx6ul-wirenboard670'
+
 
 def _get_imei():
     try:
@@ -64,8 +67,21 @@ def random_word(length):
     return ''.join(random.choice(string.lowercase) for i in range(length))
 
 
+def dt_is_compatible(compatible_str):
+    node_fname = '/proc/device-tree/compatible'
+    try:
+        compatible_with = open(node_fname).read()
+        return True if compatible_str in compatible_with else False
+    except IOError:
+        return False
+
+
 def _get_serial_2():
-    imei = _get_imei()
+    """
+    Since WB 6.7, a gsm modem has become a module => one board could have different modems
+    Modem's IMEI shouldn't be involved into WB's SN-generating process
+    """
+    imei = '' if dt_is_compatible(DT_MODEM_IS_MODULE) else _get_imei()
 
     cpuinfo_serial = str(get_cpuinfo_serial())
 
@@ -114,16 +130,23 @@ def reduce_hash(digest_str, modulo):
 
 
 def _get_serial_1():
-    wifi_mac = wifi.get_wlan_mac()
-
-    try:
-        gsm.init_gsm()
-    except RuntimeError:
-        # print "No GSM modem detected"
+    """
+    Since WB 6.7, a gsm modem has become a module => one board could have different modems
+    Modem's IMEI shouldn't be involved into WB's SN-generating process
+    """
+    if dt_is_compatible(DT_MODEM_IS_MODULE):
         imei = None
     else:
-        imei = gsm.gsm_get_imei()
-        # print "imei=%s" % imei
+        try:
+            gsm.init_gsm()
+        except RuntimeError:
+            # print "No GSM modem detected"
+            imei = None
+        else:
+            imei = gsm.gsm_get_imei()
+            # print "imei=%s" % imei
+    
+    wifi_mac = wifi.get_wlan_mac()
 
     cpuinfo_serial = str(get_cpuinfo_serial())
     # print "cpuinfo serial: ", cpuinfo_serial

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (2.1.4) stable; urgency=medium
+
+  * Modem's IMEI has removed from generating SN in WB6.7+
+
+ -- Vladimir Romanov <v.romanov@contactless.ru>  Wed, 1 Apr 2020 18:15:21 +0300
+
 wb-utils (2.1.3) stable; urgency=medium
 
   * handle auto bd synchronization in sim7000e modems

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 9), pkg-config
 
 Package: wb-utils
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, lsb-base (>= 4.1), u-boot-tools-wb (>= 2015.07+wb-3), inotify-tools, pv, jq, nginx-extras, python-wb-common (>= 1.3.2), wb-configs (>= 1.69.4), linux-image-wb2 (>= 4.9+wb20180808183130) | linux-image-wb6 (>= 4.9+wb20180808183130), device-tree-compiler
+Depends: ${shlibs:Depends}, ${misc:Depends}, lsb-base (>= 4.1), u-boot-tools-wb (>= 2015.07+wb-3), inotify-tools, pv, jq, nginx-extras, python-wb-common (>= 1.3.2), wb-configs (>= 1.69.4), linux-image-wb2 (>= 4.9+wb20200824121949) | linux-image-wb6 (>= 4.9+wb20200824121949), device-tree-compiler
 Conflicts: wb-configs (<< 1.69.4)
 Breaks: wb-homa-ism-radio (<< 1.17.2), wb-rules-system (<< 1.6.1), wb-mqtt-serial (<< 1.47.2), wb-mqtt-homeui (<< 1.7.1)
 Description: Wiren Board command-line utils

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 9), pkg-config
 
 Package: wb-utils
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, lsb-base (>= 4.1), u-boot-tools-wb (>= 2015.07+wb-3), inotify-tools, pv, jq, nginx-extras, python-wb-common (>= 1.3.2), wb-configs (>= 1.69.4), linux-image-wb2 (>= 4.9+wb20200824121949) | linux-image-wb6 (>= 4.9+wb20200824121949), device-tree-compiler
+Depends: ${shlibs:Depends}, ${misc:Depends}, lsb-base (>= 4.1), u-boot-tools-wb (>= 2015.07+wb-3), inotify-tools, pv, jq, nginx-extras, python-wb-common (>= 1.3.2), wb-configs (>= 1.69.4), linux-image-wb2 (>= 4.9+wb20180808183130) | linux-image-wb6 (>= 4.9+wb20180808183130), device-tree-compiler
 Conflicts: wb-configs (<< 1.69.4)
 Breaks: wb-homa-ism-radio (<< 1.17.2), wb-rules-system (<< 1.6.1), wb-mqtt-serial (<< 1.47.2), wb-mqtt-homeui (<< 1.7.1)
 Description: Wiren Board command-line utils


### PR DESCRIPTION
В wb6.7 генерация серийника отвязана от imei модема. Если dts compatible с contactless,imx6ul-wirenboard670 - не смотрим в imei.

Погонял на 6.6 и 6.7