### PR TITLE
WB5: Fix firmware restore.

### DIFF
--- a/board/prepare.init
+++ b/board/prepare.init
@@ -81,6 +81,8 @@ wb_prepare_partitions()
 
     wb_make_partitions ${WB_STORAGE} ${WB_ROOTFS_SIZE_MB}
 
+    partprobe ${WB_STORAGE}
+
     mkswap /dev/mmcblk0p5
 
     mkfs.ext4 /dev/mmcblk0p3 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (2.1.6) stable; urgency=medium
+
+  * Fix error on reload of partition table. (Closes: 29846) 
+
+ -- Ivan Zaentsev <ivan.zaentsev@wirenboard.ru>  Wed, 18 Nov 2020 20:00:00 +0300
+
 wb-utils (2.1.5) stable; urgency=medium
 
   * Changed at-cmd for testing connection with modem in wb-gsm

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>= 9), pkg-config
 
 Package: wb-utils
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, lsb-base (>= 4.1), u-boot-tools-wb (>= 2015.07+wb-3), inotify-tools, pv, jq, nginx-extras, python-wb-common (>= 1.3.2), wb-configs (>= 1.69.4), linux-image-wb2 (>= 4.9+wb20180808183130) | linux-image-wb6 (>= 4.9+wb20180808183130), device-tree-compiler
+Depends: ${shlibs:Depends}, ${misc:Depends}, lsb-base (>= 4.1), u-boot-tools-wb (>= 2015.07+wb-3), inotify-tools, pv, jq, nginx-extras, python-wb-common (>= 1.3.2), wb-configs (>= 1.69.4), linux-image-wb2 (>= 4.9+wb20180808183130) | linux-image-wb6 (>= 4.9+wb20180808183130), device-tree-compiler, parted
 Conflicts: wb-configs (<< 1.69.4)
 Breaks: wb-homa-ism-radio (<< 1.17.2), wb-rules-system (<< 1.6.1), wb-mqtt-serial (<< 1.47.2), wb-mqtt-homeui (<< 1.7.1)
 Description: Wiren Board command-line utils


### PR DESCRIPTION
Add partprobe call to reload partition table on ${WB_STORAGE} - fix busy error.
debian/control: Add parted dependency (for partprobe).
Update changelog.