### PR TITLE
wb-prepare: systemd services + partprobe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,18 +24,16 @@ install:
 				  board/json.sh board/of.sh board/wb_env_legacy.sh \
 				  board/wb_env.sh board/wb_env_of.sh  gsm/wb-gsm-common.sh
 
-	install -m 0755 -t $(BINDIR) board/wb-gen-serial board/wb-set-mac
+	install -m 0755 -t $(BINDIR) board/wb-gen-serial board/wb-set-mac board/wb-prepare
 	install -m 0755 -t $(BINDIR) gsm/wb-gsm gsm/wb-gsm-rtc
 
 	install -m 0755 gsm/rtc.init $(INITDIR)/wb-gsm-rtc
 	install -m 0755 board/board.init $(INITDIR)/wb-init
-	install -m 0755 board/prepare.init $(INITDIR)/wb-prepare
 	install -m 0644 board/partitions.sh $(PREPARE_LIBDIR)/partitions.sh
 	install -m 0644 board/vars.sh $(PREPARE_LIBDIR)/vars.sh
 
 	install -m 0755 -t $(BINDIR) update/wb-run-update update/wb-watch-update
 	install -m 0755 update/wb-watch-update.init $(INITDIR)/wb-watch-update
-
 
 clean:
 	@echo Nothing to do

--- a/board/wb-prepare
+++ b/board/wb-prepare
@@ -1,35 +1,10 @@
-#!/bin/bash
-### BEGIN INIT INFO
-# Provides:          wb-prepare
-# Default-Start:     S 3
-# Default-Stop:
-# Required-Start:     $local_fs
-# Required-Stop:
-# X-Start-Before:     networking watchdog
-# Short-Description:  prepare partitions & rootfs
-# Description:        prepare partitions & rootfs
-### END INIT INFO
+#!/bin/bash -e
 
-# Do NOT "set -e"
-
-# PATH should only include /usr/* if it runs after the mountnfs.sh script
-PATH=/sbin:/usr/sbin:/bin:/usr/bin
-DESC="prepare partitions & rootfs"
-NAME=wb-prepare
-SCRIPTNAME=/etc/init.d/$NAME
 ROOT_PARTITION=$(mount -l | grep " / " | cut -d " " -f1)
 
-# Load the VERBOSE setting and other rcS variables
-. /lib/init/vars.sh
-
-VERBOSE="yes"
-
-# Define LSB log_* functions.
-# Depend on lsb-base (>= 3.2-14) to ensure that this file is present
-# and status_of_proc is working.
+# legacy: load log_*_msg functions
+# once upon a time this script was an init.d script
 . /lib/lsb/init-functions
-
-. /etc/wb_env.sh
 
 # some constants for convenience
 . /usr/lib/wb-prepare/vars.sh
@@ -81,18 +56,16 @@ wb_prepare_partitions()
 
     wb_make_partitions ${WB_STORAGE} ${WB_ROOTFS_SIZE_MB}
 
+    partprobe
+
     mkswap /dev/mmcblk0p5
 
     mkfs.ext4 /dev/mmcblk0p3 
-    mkfs.ext4 /dev/mmcblk0p6 
+    mkfs.ext4 /dev/mmcblk0p6
     
-    mount /dev/mmcblk0p6 /mnt/data
-    if [[ $? = "0" ]]; then
-        touch $flag    
-    fi
-
     log_success_msg "Partition table changed, reboot needed"
     fw_setenv bootcount 0
+    sync
     reboot
 }
 
@@ -361,57 +334,27 @@ wb_firstboot()
     return 0
 }
 
-#
-# Function that starts the daemon/service
-#
-
-do_start()
+do_check_prepare()
 {
-    wb_is_firstboot || return 1
+    wb_is_firstboot || return 0
 
-    wb_prepare_partitions
     wb_prepare_filesystems
-
     wb_firstboot
-
-    return 0
 }
 
-#
-# Function that stops the daemon/service
-#
-do_stop()
-{
-	# Return
-	#   0 if daemon has been stopped
-	#   1 if daemon was already stopped
-	#   2 if daemon could not be stopped
-	#   other if a failure occurred
-
-    return 0;
-
+do_make_partitions() {
+    wb_prepare_partitions
 }
 
 case "$1" in
-  start)
-	[ "$VERBOSE" != no ] && log_daemon_msg "Starting $DESC" "$NAME" && echo
-	do_start
-	case "$?" in
-		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
-	esac
-	;;
-  stop)
-	[ "$VERBOSE" != no ] && log_daemon_msg "Stopping $DESC" "$NAME"
-	do_stop
-	case "$?" in
-		0|1) [ "$VERBOSE" != no ] && log_end_msg 0 ;;
-		2) [ "$VERBOSE" != no ] && log_end_msg 1 ;;
-	esac
-	;;
-  status)
-	 exit 0;
-	;;
+  prepare)
+    do_check_prepare
+    exit $?
+    ;;
+  make-partitions)
+    do_make_partitions
+    exit $?
+    ;;
   fix_macs)
 	wb_fix_macs
 	exit 0
@@ -421,9 +364,7 @@ case "$1" in
 	exit 0
 	;;
   *)
-	echo "Usage: $SCRIPTNAME {start|stop|status|fix_macs}" >&2
+	echo "Usage: $0 {prepare|fix_macs|fix_short_sn}" >&2
 	exit 3
 	;;
 esac
-
-:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-utils (2.3) stable; urgency=medium
+
+  * switch to systemd services from initscript
+  * fix WB5 firstboot
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 08 Jun 2021 15:18:58 +0300
+
 wb-utils (2.2) stable; urgency=medium
 
   * wb-run-update: show release information from release file

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,9 @@ Homepage: https://github.com/wirenboard/wb-utils
 
 Package: wb-utils
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, lsb-base (>= 4.1), u-boot-tools-wb (>= 2015.07+wb-3), inotify-tools, pv, jq, nginx-extras, python-wb-common (>= 1.3.2), wb-configs (>= 1.69.4), linux-image-wb2 (>= 4.9+wb20180808183130) | linux-image-wb6 (>= 4.9+wb20180808183130), device-tree-compiler
+Depends: ${shlibs:Depends}, ${misc:Depends}, lsb-base (>= 4.1), u-boot-tools-wb (>= 2015.07+wb-3), inotify-tools, pv, jq,
+         nginx-extras, python-wb-common (>= 1.3.2), wb-configs (>= 1.69.4),
+         linux-image-wb2 (>= 4.9+wb20180808183130) | linux-image-wb6 (>= 4.9+wb20180808183130), device-tree-compiler, parted
 Conflicts: wb-configs (<< 1.69.4)
 Breaks: wb-homa-ism-radio (<< 1.17.2), wb-rules-system (<< 1.6.1), wb-mqtt-serial (<< 1.47.2), wb-mqtt-homeui (<< 1.7.1)
 Description: Wiren Board command-line utils

--- a/debian/postinst
+++ b/debian/postinst
@@ -23,7 +23,6 @@ if [ "$1" = "configure" ]; then
             # update-rc.d remove refuses to remove symlinks for wb-prepare
             # because of dependencies, so let's help it using low-level insserv
             if $OLD_UPDATE_RC_D; then
-                insserv -f -r wb-prepare
                 insserv -f -r wb-gsm-rtc
             fi
         elif `dpkg --compare-versions $2 lt 1.73.1`; then
@@ -41,12 +40,7 @@ setup_systemd_service() {
     systemctl enable $1 2>/dev/null
 }
 
-if $OLD_UPDATE_RC_D; then
-    update-rc.d wb-prepare start 11 3 S . >/dev/null
-else
-    setup_systemd_service wb-prepare
-fi
-invoke-rc.d wb-prepare fix_macs
+wb-prepare fix_macs
 
 if $OLD_UPDATE_RC_D; then
     update-rc.d wb-gsm-rtc start 10 3 S . stop 10 0 6 . >/dev/null
@@ -71,3 +65,6 @@ install|upgrade|configure)
     fi
 esac
 
+#DEBHELPER#
+
+exit 0

--- a/debian/postrm
+++ b/debian/postrm
@@ -2,7 +2,6 @@
 set -e
 
 if [ "$1" = "purge" ] ; then
-	update-rc.d wb-prepare remove >/dev/null
 	update-rc.d wb-gsm-rtc remove >/dev/null
 	update-rc.d wb-init remove >/dev/null
 	update-rc.d wb-watch-update remove >/dev/null

--- a/debian/rules
+++ b/debian/rules
@@ -1,3 +1,15 @@
 #!/usr/bin/make -f
 %:
-	dh $@
+	dh $@ --with systemd
+
+override_dh_installsystemd:
+	dh_installsystemd --name=wb-prepare --no-start --no-restart-after-upgrade --no-restart-on-upgrade
+	dh_installsystemd --name=wb-repart --no-start --no-restart-after-upgrade --no-restart-on-upgrade
+
+override_dh_systemd_enable:
+	dh_systemd_enable --name=wb-prepare wb-prepare.service
+	dh_systemd_enable --name=wb-repart wb-repart.service
+
+override_dh_systemd_start:
+	dh_systemd_start --name=wb-prepare --no-start wb-prepare.service
+	dh_systemd_start --name=wb-repart --no-start wb-repart.service

--- a/debian/wb-utils.wb-prepare.service
+++ b/debian/wb-utils.wb-prepare.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=initialize filesystems at first boot
+Conflicts=shutdown.target
+Before=network.target watchdog.service shutdown.target
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/wb-prepare prepare
+
+[Install]
+WantedBy=sysinit.target

--- a/debian/wb-utils.wb-repart.service
+++ b/debian/wb-utils.wb-repart.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=prepare partitions at first boot
+DefaultDependencies=no
+Conflicts=shutdown.target
+Before=local-fs-pre.target shutdown.target
+After=systemd-remount-fs.service
+RefuseManualStop=true
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/wb-prepare make-partitions
+
+[Install]
+WantedBy=sysinit.target


### PR DESCRIPTION
  * split wb-prepare to wb-repart (creates partitions before
    basic.target) and wb-prepare as it was
  * use systemd services instead of lsb script
  * add partprobe after creating partitions
  * prepare filesystems in second stage

This fixes #29846