### PR TITLE
added timeout between toggling power and pwrkey in wb-gsm

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (2.3.1) stable; urgency=medium
+
+  * Added timeout between toggling power and pwrkey in wb-gsm
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Tue, 01 Aug 2021 16:46:33 +0300
+
 wb-utils (2.3) stable; urgency=medium
 
   * switch to systemd services from initscript

--- a/gsm/wb-gsm-common.sh
+++ b/gsm/wb-gsm-common.sh
@@ -115,6 +115,7 @@ function toggle() {
     fi
 
 
+    sleep 1
     gpio_set_value $WB_GPIO_GSM_PWRKEY 0
     sleep 1
     gpio_set_value $WB_GPIO_GSM_PWRKEY 1


### PR DESCRIPTION
По мотивам инженерного чатика (02.08.21). Проблема с WBC-4G. Не включается с первого раза, если неправильно выключить. Вылечилось слипом перед pwrkey_toggle; непонятно, почему

Проверил с WBC-4G, WBC-2G (sim800c-ds), WBC-3G. В любом случае, хуже от слипа не будет