### PR TITLE
Feature/41804 modem no uart

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,11 @@
 wb-utils (3.5.0) stable; urgency=medium
 
-  * wb-gsm: added usb-only modems support (wb6, wb7)
   * wb_env_of: added usb-modem node for parsing gpios
+  * wb-gsm: added usb-only modems support (wb6, wb7)
+  * wb-gsm: directly parsing modem-toggling gpios from appropriate of_node
+  * wb-gsm: /dev/ttyGSM* are symlinks to actual modem's at-ports
 
- -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 02 Feb 2022 02:01:53 +0300
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 23 Feb 2022 20:23:12 +0300
 
 wb-utils (3.4.1) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
-wb-utils (3.4.2) stable; urgency=medium
+wb-utils (3.5.0) stable; urgency=medium
 
-  * wb-gsm: added usb-only modems support
+  * wb-gsm: added usb-only modems support (wb6, wb7)
 
  -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 02 Feb 2022 02:01:53 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (3.4.1) stable; urgency=medium
+
+  * wb-gsm: added support of usb-only modems
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 01 Feb 2022 01:53:17 +0300
+
 wb-utils (3.4.0) stable; urgency=medium
 
   * image-postinst: add script to update u-boot during factory reset

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 wb-utils (3.5.0) stable; urgency=medium
 
   * wb-gsm: added usb-only modems support (wb6, wb7)
+  * wb_env_of: added usb-modem node for parsing gpios
 
  -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 02 Feb 2022 02:01:53 +0300
 

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Package: wb-utils
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, lsb-base (>= 4.1), u-boot-tools-wb (>= 2015.07+wb-3), inotify-tools, pv, jq,
          nginx-extras, python-wb-common (>= 1.4.0~~), wb-configs (>= 1.69.4), util-linux,
-         linux-image-wb2 (>= 4.9+wb20180808183130) | linux-image-wb6 (>= 4.9+wb20180808183130) | linux-image-wb7,
+         linux-image-wb2 (>= 4.9+wb20180808183130) | linux-image-wb6 (>= 5.10.35-wb106~~) | linux-image-wb7 (>= 5.10.35-wb106~~),
          device-tree-compiler, parted, rsync
 Conflicts: wb-configs (<< 1.69.4)
 Breaks: wb-homa-ism-radio (<< 1.17.2), wb-rules-system (<< 1.6.1), wb-mqtt-serial (<< 1.47.2), wb-mqtt-homeui (<< 1.7.1)

--- a/utils/bin/wb-gsm
+++ b/utils/bin/wb-gsm
@@ -2,6 +2,10 @@
 
 . /usr/lib/wb-utils/wb-gsm-common.sh
 
+WB_GSM_PID=$$
+trap "force_exit_handler" TERM
+
+guess_of_node
 gsm_init
 
 case "$1" in
@@ -44,7 +48,3 @@ case "$1" in
         echo "USAGE: $0 reset|toggle|on|restart_if_broken|off|set_speed|init_baud|imei|imei_sn";
     ;;
 esac
-
-
-
-

--- a/utils/lib/wb-gsm-common.sh
+++ b/utils/lib/wb-gsm-common.sh
@@ -19,7 +19,7 @@ function has_uart() {
 function get_modem_usb_devices() {
     # modem is connected to it's own usb-hub with known address (from wirenboard/gsm node)
     # returns all devices on this hub
-    echo $(readlink -m /sys/bus/usb-serial/devices/* | grep $(of_get_prop_str "wirenboard/gsm" "usb-soc-addr"));
+    echo $(readlink -f /dev/serial/by-path/platform-$(of_get_prop_str "wirenboard/gsm" "usb-soc-addr")*);
 }
 
 
@@ -34,10 +34,9 @@ function test_connection() {
 function get_at_port() {
     # a usb-connected modem produces multiple devices
     # trying to guess, which one is at-port
-    for port_params in $(get_modem_usb_devices); do
-        portname="/dev/$(echo $port_params | grep -o 'tty.*$')"
-        if [[ $(test_connection $portname 2) == 0 ]] ; then
-            echo "$portname"
+    for port in $(get_modem_usb_devices); do
+        if [[ $(test_connection $port 2) == 0 ]] ; then
+            echo "$port"
             break
         fi
     done

--- a/utils/lib/wb-gsm-common.sh
+++ b/utils/lib/wb-gsm-common.sh
@@ -26,8 +26,14 @@ function get_modem_usb_devices() {
     # usb-port, modem connected to, is binded in device-tree
     # returns all tty devices on this port
     local compatible_str="wirenboard,wbc-usb-modem"
-    local usb_root=$(grep -l $compatible_str /sys/bus/usb/devices/*/of_node/compatible | sed 's/of_node\/compatible//')
-    [[ -z $usb_root ]] && echo $usb_root || echo $(ls $usb_root*/ | grep -o 'tty.*$')
+
+    for device in $(ls -d /sys/bus/usb/devices/*/of_node); do
+        if of_node_match $(readlink -f $device) $compatible_str &>/dev/null; then
+            usb_root=$(echo $device | sed 's/of_node//')
+            break
+        fi
+    done
+    [[ -z $usb_root ]] && echo $usb_root || echo $(ls $usb_root* | grep -o 'tty.*$')
 }
 
 

--- a/utils/lib/wb-gsm-common.sh
+++ b/utils/lib/wb-gsm-common.sh
@@ -366,7 +366,10 @@ function imei_sn() {
 
 
 function switch_off() {
-    debug "Try to switch off GSM modem "
+    [[ -n ${WB_GPIO_GSM_STATUS} ]] && [[ "`gpio_get_value ${WB_GPIO_GSM_STATUS}`" = "0" ]] && {
+        debug "Modem is already OFF"
+        return 0
+    } || debug "Modem is ON. Will try to switch off GSM modem "
 
     if [[ ${WB_GSM_POWER_TYPE} = "1" ]]; then
         debug "resetting GSM modem first"

--- a/utils/lib/wb-gsm-common.sh
+++ b/utils/lib/wb-gsm-common.sh
@@ -4,6 +4,9 @@
 wb_source "hardware"
 wb_source "of"
 
+trap "exit 1" TERM
+WB_GSM_PID=$$
+
 DEFAULT_BAUDRATE=115200
 PORT=/dev/ttyGSM
 USB_SYMLINK_MASK="/dev/ttyGSM"
@@ -124,6 +127,21 @@ function init_usb_connection() {
     exit 1
 }
 
+function of_prop_required() {
+    # hiding tons of debug output in of_* funcs
+    # terminating wb-gsm, if required of_prop is missing
+    [[ $# -ne 3 ]] && {
+        echo "${FUNCNAME[1]}: of_parsing_func of_node prop"
+        kill -s TERM $WB_GSM_PID
+    }
+
+    local of_node=$2
+    local prop=$3
+    of_has_prop $of_node $prop && echo "$($@ 2>/dev/null)" || {  # of_get_prop* return 0 even if prop is missing
+        debug "Required prop $of_node->$prop is missing!"
+        kill -s TERM $WB_GSM_PID
+    }
+}
 
 function get_model() {
     set_speed
@@ -183,7 +201,7 @@ function is_neoway_m660a() {
 
 
 function gsm_present() {
-    [[ -n "${WB_GSM_POWER_TYPE}" ]] && [[ "$WB_GSM_POWER_TYPE" != "0" ]]
+    of_has_prop $OF_GSM_NODE "power-type" && [[ $(of_get_prop_ulong $OF_GSM_NODE "power-type") != "0" ]]
 }
 
 function gsm_init() {
@@ -203,35 +221,41 @@ function gsm_init() {
         fi
     fi
 
-    gpio_setup $WB_GPIO_GSM_PWRKEY out
+    local gpio_gsm_pwrkey=$(of_prop_required of_get_prop_gpionum $OF_GSM_NODE "pwrkey-gpios")
+    local gsm_power_type=$(of_prop_required of_get_prop_ulong $OF_GSM_NODE "power-type")
+    local gpio_gsm_power=$(of_prop_required of_get_prop_gpionum $OF_GSM_NODE "power-gpios")
+    local gpio_gsm_status=$(of_prop_required of_get_prop_gpionum $OF_GSM_NODE "status-gpios")
 
+    gpio_setup $gpio_gsm_pwrkey out
 
-    if [[ ${WB_GSM_POWER_TYPE} = "1" ]]; then
-        gpio_setup $WB_GPIO_GSM_RESET low
+    if [[ $gsm_power_type = "1" ]]; then
+        local gpio_gsm_reset=$(of_prop_required of_get_prop_gpionum $OF_GSM_NODE "reset-gpios")
+        gpio_setup $gpio_gsm_reset low
     fi
 
-    if [[ ${WB_GSM_POWER_TYPE} = "2" ]]; then
-        gpio_setup $WB_GPIO_GSM_POWER out
+    if [[ $gsm_power_type = "2" ]]; then
+        gpio_setup $gpio_gsm_power out
     fi
 
-    if [[ -n ${WB_GPIO_GSM_STATUS} ]]; then
-        gpio_setup $WB_GPIO_GSM_STATUS in
-        if [[ ${WB_GPIO_GSM_STATUS_INVERTED} = "1" ]]; then
-            gpio_set_inverted $WB_GPIO_GSM_STATUS 1
+    if [[ -n $gpio_gsm_status ]]; then
+        gpio_setup $gpio_gsm_status in
+        if of_gpio_is_inverted $(of_prop_required of_get_prop_gpio $OF_GSM_NODE "status-gpios"); then
+            gpio_set_inverted $gpio_gsm_status 1
         else
-            gpio_set_inverted $WB_GPIO_GSM_STATUS 0
+            gpio_set_inverted $gpio_gsm_status 0
         fi
     fi
 
-    if [[ ! -z $WB_GPIO_GSM_SIMSELECT ]]; then
-        gpio_export $WB_GPIO_GSM_SIMSELECT
-        gpio_set_dir $WB_GPIO_GSM_SIMSELECT out
+    if of_has_prop $OF_GSM_NODE "simselect-gpios"; then  # some wb5's modems have not simselect
+        local gpio_gsm_simselect=$(of_prop_required of_get_prop_gpionum $OF_GSM_NODE "simselect-gpios")
+        gpio_export $gpio_gsm_simselect
+        gpio_set_dir $gpio_gsm_simselect out
         # select SIM1 at startup
-        gpio_set_value $WB_GPIO_GSM_SIMSELECT 0
+        gpio_set_value $gpio_gsm_simselect 0
     fi
 
     if has_usb; then
-        if [[ `gpio_get_value $WB_GPIO_GSM_STATUS` -eq "1" ]]; then
+        if [[ `gpio_get_value $gpio_gsm_status` -eq "1" ]]; then
             debug "USB modem is turned on already; probing ($PORT, ${USB_SYMLINK_MASK}*) ports"
             for port in $PORT ${USB_SYMLINK_MASK}[0-9]*; do
                 [[ -e $port ]] && [[ $(test_connection $port 2) == 0 ]] && {
@@ -246,36 +270,42 @@ function gsm_init() {
 
 
 function toggle() {
+    local gsm_power_type=$(of_prop_required of_get_prop_ulong $OF_GSM_NODE "power-type")
+    local gpio_gsm_power=$(of_prop_required of_get_prop_gpionum $OF_GSM_NODE "power-gpios")
+    local gpio_gsm_pwrkey=$(of_prop_required of_get_prop_gpionum $OF_GSM_NODE "pwrkey-gpios")
+
     debug "toggle GSM modem state using PWRKEY"
 
-    if [[ ${WB_GSM_POWER_TYPE} = "2" ]]; then
-        gpio_set_value $WB_GPIO_GSM_POWER 1
+    if [[ $gsm_power_type = "2" ]]; then
+        gpio_set_value $gpio_gsm_power 1
     fi
 
-
     sleep 1
-    gpio_set_value $WB_GPIO_GSM_PWRKEY 0
+    gpio_set_value $gpio_gsm_pwrkey 0
     sleep 1
-    gpio_set_value $WB_GPIO_GSM_PWRKEY 1
+    gpio_set_value $gpio_gsm_pwrkey 1
     sleep 1
-    gpio_set_value $WB_GPIO_GSM_PWRKEY 0
+    gpio_set_value $gpio_gsm_pwrkey 0
 }
 
 function reset() {
+    local gsm_power_type=$(of_prop_required of_get_prop_ulong $OF_GSM_NODE "power-type")
+    local gpio_gsm_power=$(of_prop_required of_get_prop_gpionum $OF_GSM_NODE "power-gpios")
 
-    if [[ ${WB_GSM_POWER_TYPE} = "1" ]]; then
+    if [[ $gsm_power_type = "1" ]]; then
         debug "Resetting GSM modem using RESET pin"
-        gpio_set_value $WB_GPIO_GSM_RESET 1
+        local gpio_gsm_reset=$(of_prop_required of_get_prop_gpionum $OF_GSM_NODE "reset-gpios")
+        gpio_set_value $gpio_gsm_reset 1
         sleep 0.5
-        gpio_set_value $WB_GPIO_GSM_RESET 0
+        gpio_set_value $gpio_gsm_reset 0
         sleep 0.5
     fi
 
-    if [[ ${WB_GSM_POWER_TYPE} = "2" ]]; then
+    if [[ $gsm_power_type = "2" ]]; then
         debug "Resetting GSM modem using POWER FET"
-        gpio_set_value $WB_GPIO_GSM_POWER 0
+        gpio_set_value $gpio_gsm_power 0
         sleep 0.5
-        gpio_set_value $WB_GPIO_GSM_POWER 1
+        gpio_set_value $gpio_gsm_power 1
         sleep 0.5
     fi
 
@@ -358,17 +388,17 @@ function imei_sn() {
     echo ${IMEI_SN}
 }
 
-
-
-
-
 function switch_off() {
-    [[ -n ${WB_GPIO_GSM_STATUS} ]] && [[ "`gpio_get_value ${WB_GPIO_GSM_STATUS}`" = "0" ]] && {
+    local gpio_gsm_status=$(of_prop_required of_get_prop_gpionum $OF_GSM_NODE "status-gpios")
+    local gsm_power_type=$(of_prop_required of_get_prop_ulong $OF_GSM_NODE "power-type")
+    local gpio_gsm_power=$(of_prop_required of_get_prop_gpionum $OF_GSM_NODE "power-gpios")
+
+    [[ -n $gpio_gsm_status ]] && [[ "`gpio_get_value $gpio_gsm_status`" = "0" ]] && {
         debug "Modem is already OFF"
         return 0
     } || debug "Modem is ON. Will try to switch off GSM modem "
 
-    if [[ ${WB_GSM_POWER_TYPE} = "1" ]]; then
+    if [[ $gsm_power_type = "1" ]]; then
         debug "resetting GSM modem first"
         reset
         sleep 3
@@ -379,12 +409,12 @@ function switch_off() {
     echo  -e "AT+CPOWD=1\r\n" > $PORT # for SIMCOM
     echo  -e "AT+CPWROFF\r\n" > $PORT # for SIMCOM
 
-    if [[ -n ${WB_GPIO_GSM_STATUS} ]]; then
+    if [[ -n $gpio_gsm_status ]]; then
         debug "Waiting for modem to stop"
         max_tries=25
 
         for ((i=0; i<=upperlim; i++)); do
-            if [[ "`gpio_get_value ${WB_GPIO_GSM_STATUS}`" = "0" ]]; then
+            if [[ "`gpio_get_value $gpio_gsm_status`" = "0" ]]; then
                 break
             fi
             sleep 0.2
@@ -395,19 +425,19 @@ function switch_off() {
 
     unlink_ports
 
-    if [[ ${WB_GSM_POWER_TYPE} = "2" ]]; then
+    if [[ $gsm_power_type = "2" ]]; then
         debug "physically switching off GSM modem using POWER FET"
-        gpio_set_value $WB_GPIO_GSM_POWER 0
+        gpio_set_value $gpio_gsm_power 0
     fi;
-
-
-
-
 }
 
 function ensure_on() {
-    if [[ -n "${WB_GPIO_GSM_STATUS}" ]]; then
-        if [[ "`gpio_get_value ${WB_GPIO_GSM_STATUS}`" = "1" ]]; then
+    local gpio_gsm_status=$(of_prop_required of_get_prop_gpionum $OF_GSM_NODE "status-gpios")
+    local gsm_power_type=$(of_prop_required of_get_prop_ulong $OF_GSM_NODE "power-type")
+    local gpio_gsm_power=$(of_prop_required of_get_prop_gpionum $OF_GSM_NODE "power-gpios")
+
+    if [[ -n "$gpio_gsm_status" ]]; then
+        if [[ "`gpio_get_value $gpio_gsm_status`" = "1" ]]; then
             debug "Modem is already switched on"
             return
         fi
@@ -415,19 +445,19 @@ function ensure_on() {
         switch_off
     fi
 
-    if [[ ${WB_GSM_POWER_TYPE} = "2" ]]; then
+    if [[ $gsm_power_type = "2" ]]; then
         debug "switching on GSM modem using POWER FET"
-        gpio_set_value $WB_GPIO_GSM_POWER 1
+        gpio_set_value $gpio_gsm_power 1
     fi;
 
     toggle
 
-    if [[ -n "${WB_GPIO_GSM_STATUS}" ]]; then
+    if [[ -n "$gpio_gsm_status" ]]; then
         debug "Waiting for modem to start"
         max_tries=30
 
         for ((i=0; i<=max_tries; i++)); do
-            if [[ "`gpio_get_value ${WB_GPIO_GSM_STATUS}`" = "1" ]]; then
+            if [[ "`gpio_get_value $gpio_gsm_status`" = "1" ]]; then
                 break
             fi
             sleep 0.1
@@ -453,10 +483,12 @@ function ensure_on() {
 
 
 function restart_if_broken() {
+    local gpio_gsm_status=$(of_prop_required of_get_prop_gpionum $OF_GSM_NODE "status-gpios")
+
     #~ set_speed
     local RC=0
-    if [[ -n "${WB_GPIO_GSM_STATUS}" ]]; then
-        if [[ "`gpio_get_value ${WB_GPIO_GSM_STATUS}`" = "0" ]]; then
+    if [[ -n "$gpio_gsm_status" ]]; then
+        if [[ "`gpio_get_value $gpio_gsm_status`" = "0" ]]; then
             debug "Modem switched off, switch it on instead of testing the connection"
             local RC=1
         fi


### PR DESCRIPTION
Поддержка USB-онли модемов (т.к. в wb7 нет uart для этого). UART+usb модемы ведут себя, как раньше

Основная идея - знаем, что модем висит на своём отдельном USB и смотрим, какие устройства на нем появляются. Погонял - работают: a7600e, sim7000e (nb-iot), sim5300e, quectel ec200t. По идее, будет работать на всех, где есть usb-at. Должен работать и wbc-2g v.2 (но с переключенным at-портом на usb)

адрес usb предлагаю брать из device-tree (там захардкодил)
связанные PR: [ядро](https://github.com/wirenboard/linux/pull/78), [hwconf](https://github.com/wirenboard/linux/pull/78)