### PR TITLE
wb-gsm: added turning off gsm_power (if available) to force_exit func

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (3.5.1) stable; urgency=medium
+
+  * wb-gsm: added turning modem's power off in force_exit handler
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 19 May 2022 16:00:47 +0300
+
 wb-utils (3.5.0) stable; urgency=medium
 
   * wb_env_of: added usb-modem node for parsing gpios

--- a/utils/lib/wb-gsm-common.sh
+++ b/utils/lib/wb-gsm-common.sh
@@ -34,8 +34,13 @@ function is_at_over_usb() {
 }
 
 function force_exit() {
-    # exitting (to where the trap to TERM signal placed) from any inner-func
+    # exitting (to where the trap to TERM signal placed) from any inner-func (with turning GSM_POWER off if available)
     # default trap to ERR waits a caller to finish, which sometimes is not suitable
+    [[ -n $OF_GSM_NODE ]] && of_has_prop $OF_GSM_NODE "power-gpios" && {
+        >&2 echo "Turning OFF modem's POWER FET"
+        gpio_set_value $(of_get_prop_gpionum $OF_GSM_NODE "power-gpios") 0
+    }
+
     >&2 echo "Force exit: $@"
     for (( i = 1; i < ${#FUNCNAME[@]} - 1; i++ )); do
         >&2 echo " $i: ${BASH_SOURCE[$i+1]}:${BASH_LINENO[$i]} ${FUNCNAME[$i]}(...)"

--- a/utils/lib/wb-gsm-common.sh
+++ b/utils/lib/wb-gsm-common.sh
@@ -36,10 +36,12 @@ function is_at_over_usb() {
 function force_exit() {
     # exitting (to where the trap to TERM signal placed) from any inner-func (with turning GSM_POWER off if available)
     # default trap to ERR waits a caller to finish, which sometimes is not suitable
-    [[ -n $OF_GSM_NODE ]] && of_has_prop $OF_GSM_NODE "power-gpios" && {
-        >&2 echo "Turning OFF modem's POWER FET"
-        gpio_set_value $(of_get_prop_gpionum $OF_GSM_NODE "power-gpios") 0
-    }
+    if [[ -n "$OF_GSM_NODE" ]]; then
+        if of_has_prop $OF_GSM_NODE "power-gpios"; then
+            >&2 echo "Turning OFF modem's POWER FET"
+            gpio_set_value $(of_get_prop_gpionum $OF_GSM_NODE "power-gpios") 0
+        fi
+    fi
 
     >&2 echo "Force exit: $@"
     for (( i = 1; i < ${#FUNCNAME[@]} - 1; i++ )); do


### PR DESCRIPTION
раньше модем мог навсегда остаться зависшим: 
работал => завис => wb-gsm off дернул gsm_init, в котором проверяются usb-порты, если модем включен и есть симлинки => ни один порт не ответил

решение снимать питание именно в force_exit кажется мне наиболее разумным с точки зрения внутреннего устройства wb-gsm

модем завесить у меня не получается => работоспособность проверял, поигравшись с таймаутом появления usb-портов при старте