### PR TITLE
wb-gsm: not toggling simselect-gpio, if already exported

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (3.6.1) stable; urgency=medium
+
+  * wb-gsm: not toggling simselect gpio, if already exported
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 30 Jun 2022 10:10:43 +0300
+
 wb-utils (3.6.0) stable; urgency=medium
 
   * wb-run-update: add --no-confirm option to run factory reset

--- a/utils/lib/wb-gsm-common.sh
+++ b/utils/lib/wb-gsm-common.sh
@@ -271,10 +271,13 @@ function gsm_init() {
 
     if of_has_prop $OF_GSM_NODE "simselect-gpios"; then  # some wb5's modems have not simselect
         local gpio_gsm_simselect=$(of_prop_required of_get_prop_gpionum $OF_GSM_NODE "simselect-gpios")
-        gpio_export $gpio_gsm_simselect
-        gpio_set_dir $gpio_gsm_simselect out
-        # select SIM1 at startup
-        gpio_set_value $gpio_gsm_simselect 0
+        if [[ ! -e "$(gpio_attr_path "$gpio_gsm_simselect")" ]]; then
+            gpio_export $gpio_gsm_simselect
+            gpio_set_dir $gpio_gsm_simselect out
+            local simselect_val=0  # SIM1 is active
+            gpio_set_value $gpio_gsm_simselect $simselect_val
+            debug "Exported and toggled SIMSELECT (gpio$gpio_gsm_simselect -> $simselect_val)"
+        fi
     fi
 
     if has_usb; then


### PR DESCRIPTION
проблема - при каждом запуске wb-gsm экспортировался и настраивался в 0 simselect gpio => клиенту очень сложно переключить sim-карту

решение - не трогаем gpio, если он уже экспортирован (а экспортируется и выставляется в 0 - при первом запуске wb-gsm после ребута wb)