### PR TITLE
wb-watch-update: add delay before sending log/status to mqtt

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-utils (3.7.0) stable; urgency=medium
+
+  * wb-watch-update: add delay before sending log/status to mqtt
+  to prevent conflicts in webui's download progress displaying
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Tue, 5 Jul 2022 13:54:29 +0300
+
 wb-utils (3.6.1) stable; urgency=medium
 
   * wb-gsm: not toggling simselect gpio, if already exported

--- a/utils/bin/wb-watch-update
+++ b/utils/bin/wb-watch-update
@@ -36,6 +36,8 @@ mqtt_log_pipe() {
 	mosquitto_pub -t /firmware/log -l
 }
 
+FRONTEND_STATUS_UPDATE_TIMEOUT=2  # to prevent overwriting from nginx's cgi output
+
 LAST_FIT=''
 
 (
@@ -53,6 +55,11 @@ done
 
 while read EVENT_DIR EVENT_TYPE EVENT_FILE; do
 	FIT="${EVENT_DIR}${EVENT_FILE}"
+
+	# While uploading files via cgi, output is always buffered =>
+	# mqtt_log/status got by frontend earlier than cgi output
+	log "Uploaded: ${FIT}; waiting ${FRONTEND_STATUS_UPDATE_TIMEOUT}s"
+	sleep $FRONTEND_STATUS_UPDATE_TIMEOUT
 
 	# Prevent endless loop
 	[[ "$FIT" != "$LAST_FIT" ]] || continue


### PR DESCRIPTION
Связянный загрузкой обновления (нжинкс) pr.
Вкратце - wb-watch-update видит файл и шлет лог раньше, чем закончился cgi-скрипт => в прогрессбаре загрузки этого не видно
![2022-07-05_14-52-42](https://user-images.githubusercontent.com/25829054/177321376-c8e518c4-4751-4c6a-b4bc-67bd514cefda.png)

Подробно - в pr'е в wb-configs


по идее, от задержки здесь никому ни жарко, ни холодно. Проверю на вб на стретче, как буду в офисе (завтра)