### PR TITLE
wb-gsm-rtc: fix modem dt_node definition

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (3.6.2) stable; urgency=medium
+
+  * wb-gsm-rtc: fix modem dt_node definition
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Mon, 18 Jul 2022 10:19:29 +0300
+
 wb-utils (3.6.1) stable; urgency=medium
 
   * wb-gsm: not toggling simselect gpio, if already exported

--- a/utils/bin/wb-gsm-rtc
+++ b/utils/bin/wb-gsm-rtc
@@ -12,6 +12,7 @@ function sys_set_time() {
     date -u -s "20${DATE/,/ }"
 }
 
+guess_of_node
 
 case "$1" in
 	"save_time" )
@@ -44,4 +45,3 @@ case "$1" in
 		echo "USAGE: $0 [save_time|restore_time|read|present]";
 	;;
 esac
-


### PR DESCRIPTION
После больших изменений в wb-gsm, модемная нода перестала быть захардкоженной и стала определяться из алиаса (с wirenboard/gsm, как fallback)

проглядели wb-gsm-rtc
=> ничего не работало, т.к. не срабатывали gsm_present и gsm_init

p.s. видимо, никто этим не пользуется, раз заметили только сейчас