### PR TITLE
of: fix type deduction for bullseye

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (3.8.0) stable; urgency=medium
+
+  * of: fix type deduction for bullseye
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Thu, 18 Aug 2022 14:04:36 +0300
+
 wb-utils (3.7.0) stable; urgency=medium
 
   * wb-gen-serial: do not use eth0 MAC for serial generation on WB 7.3+

--- a/utils/lib/of.sh
+++ b/utils/lib/of.sh
@@ -44,7 +44,7 @@ split_each() {
 # heuristics and not to confuse user
 guess_data_type() {
 	which file >/dev/null || echo "int"
-	local guess=`cat | file -e apptype -e compress -e elf -e encoding \
+	local guess=`cat | head -c -1 | file -e apptype -e compress -e elf -e encoding \
 	        -e soft -e tar -`
 	case $guess in *ASCII*) echo "string" ;; *) echo "int" ;; esac
 }


### PR DESCRIPTION
В bullseye поменялась логика работы утилиты `file`, которая раньше могла интерпретировать содержиме файла с тестом и нулевым символом как текст, а теперь не может. Из-за этого магия, которая читает данные в bash из device-tree, сломалась, и вместо текста выдавала цифры.

Этот патч чинит поведение преобразования данных для bullseye.