### PR TITLE
Feature/52212 turning on fixups

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-utils (4.1.1) stable; urgency=medium
+
+  * wb-gsm: add delay before usb ports probing at poweron
+  * wb-gsm: rework chat timeout setting (at connection test)
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Tue, 22 Sep 2022 22:48:47 +0300
+
 wb-utils (4.1.0) stable; urgency=medium
 
   * wb-gsm: add GSM modem power management for use with ModemManager

--- a/utils/lib/wb-gsm-common.sh
+++ b/utils/lib/wb-gsm-common.sh
@@ -73,7 +73,7 @@ function get_modem_usb_devices() {
 
 
 function test_connection() {
-    /usr/sbin/chat -v   TIMEOUT $2 ABORT "ERROR" ABORT "BUSY" "" AT OK "" > $1 < $1
+    /usr/sbin/chat -t $2 -v ABORT "ERROR" ABORT "BUSY" "" AT OK "" > $1 < $1
     RC=$?
     debug "(port:$1; timeout:$2) => $RC"
     echo $RC

--- a/utils/lib/wb-gsm-common.sh
+++ b/utils/lib/wb-gsm-common.sh
@@ -493,6 +493,8 @@ function ensure_on() {
     fi
 
     if has_usb; then
+        debug "Waiting 10s before probing usb ports..."
+        sleep 10  # Some A7600Es got stuck, when probing usb connection just after poweron
         init_usb_connection
     fi
 


### PR DESCRIPTION
странное поведение модема из [темы на форуме](https://support.wirenboard.com/t/neustojchivoe-opredelenie-modema-wbc-4g/12219/60). Основной симптом - chat зависает на проверке соединения по usb-портам

общался/лазил по энидеску у клиента с похожей проблемой (недели 2 назад). Собрал ему дебку с этими изменениями - помогло