### PR TITLE
Feature/52212 turning on fixups (#51)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-utils (3.7.0-wb2) stable; urgency=medium
+
+  * wb-gsm: add delay before usb ports probing at poweron
+  * wb-gsm: rework chat timeout setting (at connection test)
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Mon, 26 Sep 2022 14:36:47 +0300
+
 wb-utils (3.7.0-wb1) stable; urgency=medium
 
   * wb-gen-serial: fix serial generation on WB7 with modems

--- a/utils/lib/wb-gsm-common.sh
+++ b/utils/lib/wb-gsm-common.sh
@@ -73,7 +73,7 @@ function get_modem_usb_devices() {
 
 
 function test_connection() {
-    /usr/sbin/chat -v   TIMEOUT $2 ABORT "ERROR" ABORT "BUSY" "" AT OK "" > $1 < $1
+    /usr/sbin/chat -t $2 -v ABORT "ERROR" ABORT "BUSY" "" AT OK "" > $1 < $1
     RC=$?
     debug "(port:$1; timeout:$2) => $RC"
     echo $RC
@@ -493,6 +493,8 @@ function ensure_on() {
     fi
 
     if has_usb; then
+        debug "Waiting 10s before probing usb ports..."
+        sleep 10  # Some A7600Es got stuck, when probing usb connection just after poweron
         init_usb_connection
     fi
 


### PR DESCRIPTION
* wb-gsm: setting initial timeout to whole chat conversation (instead of new expect-string only)

* wb-gsm: add delay before usb ports probing at poweron

* wb-gsm: bump version


бекпорт в 2207 вокругмодемных фиксов из недавнего PR