### PR TITLE
Fix GSM modem power up on Wiren Board 7

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.2.2) stable; urgency=medium
+
+  * Fix GSM modem power up on Wiren Board 7
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Fri, 30 Sep 2022 12:22:11 +0500
+
 wb-utils (4.2.1) stable; urgency=medium
 
   * wb-gsm: add delay before usb ports probing at poweron

--- a/utils/lib/wb-gsm-common.sh
+++ b/utils/lib/wb-gsm-common.sh
@@ -693,7 +693,7 @@ function wb7_off() {
 
 function should_enable() {
     if has_usb; then
-        if [[ of_machine_match "wirenboard,wirenboard-720" || of_machine_match "wirenboard,wirenboard-7xx" ]]; then
+        if of_machine_match "wirenboard,wirenboard-720" || of_machine_match "wirenboard,wirenboard-7xx"; then
             debug "Should enable GSM modem"
             return 0
         else


### PR DESCRIPTION
Ругалось так
```
root@wirenboard-APT6KWYK:~# wb-gsm --help
/usr/lib/wb-utils/wb-gsm-common.sh: строка 696: ожидается условный бинарный оператор
/usr/lib/wb-utils/wb-gsm-common.sh: строка 696: синтаксическая ошибка рядом с «"wirenboard,wirenboard-720"»
/usr/lib/wb-utils/wb-gsm-common.sh: строка 696: `        if [[ of_machine_match "wirenboard,wirenboard-720" || of_machine_match "wirenboard,wirenboard-7xx" ]]; then'
```