### PR TITLE
wb-prepare: fix failure in case of not-responding gsm modem (wb6x)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.2.3) stable; urgency=medium
+
+  * wb-prepare: fix failure in case of not-responding gsm modem (wb6x)
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Tue, 11 Oct 2022 20:23:12 +0300
+
 wb-utils (4.2.2) stable; urgency=medium
 
   * Fix GSM modem power up on Wiren Board 7

--- a/utils/lib/prepare/wb-prepare.sh
+++ b/utils/lib/prepare/wb-prepare.sh
@@ -262,7 +262,7 @@ wb_firstboot()
 
     [[ -e "/dev/ttyGSM" ]] && {
 		log_action_begin_msg "Fixing GSM modem baudrate"
-		wb-gsm init_baud
+		wb-gsm init_baud || log_failure_msg "No answer from gsm modem"
 		log_end_msg $?
     }
 


### PR DESCRIPTION
по мотивам wb6.5.1, "потерявших серийники после factoryreset"
имеем несколько (на самом деле, один) wb6x с нерабочим sim5300e от клиента

в wb-gen-serial обошли везде ситуацию, когда модем не отвечает, а про wb-gsm init_baud - забыли.
=> wb_firstboot падает на середине, не успев установить хостнейм, наделать ssh ключей и т.д.

у Ильи "работало на старой прошивке" - т.к. раньше (в релизе 2201) у wb-gsm были поломаны exit-коды -> это место не стреляло


надо в 2207 бекпортировать, думаю