### PR TITLE
Custom serial number value from overlay (wb-2207 port)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (3.7.0-wb105) stable; urgency=medium
+
+  * wb-gen-serial: add custom serial support
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Thu, 27 Oct 2022 19:06:14 +0600
+
 wb-utils (3.7.0-wb4) stable; urgency=medium
 
   * wb-prepare: fix failure in case of not-responding gsm modem (wb6x)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-utils (3.7.0-wb105) stable; urgency=medium
 
-  * wb-gen-serial: add custom serial support
+  * wb-gen-serial: add overridable factory serial support
 
  -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Thu, 27 Oct 2022 19:06:14 +0600
 

--- a/utils/bin/wb-gen-serial
+++ b/utils/bin/wb-gen-serial
@@ -59,6 +59,15 @@ def has_wb_factory_mac(iface):
     return os.path.isfile("/proc/device-tree/wirenboard/%s-mac-address" % iface)
 
 
+def get_custom_serial():
+    path = "/proc/device-tree/wirenboard/device-serial"
+    if os.path.isfile(path):
+        with open(path, "r") as f:
+            return f.read().strip()
+    else:
+        return None
+
+
 def pack_long(num):
     ret = ""
     while num > 0:
@@ -198,6 +207,10 @@ def _get_serial_1():
 
 
 def get_serial(version=2):
+    custom = get_custom_serial()
+    if custom is not None:
+        return custom
+
     if version == 2:
         return _get_serial_2()
     else:


### PR DESCRIPTION
Нужно для некоторых контроллеров, для которых специальный серийный номер прописывается на этапе инициализации.
