### PR TITLE
trim zeros from custom serial value

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (3.7.0-wb106) stable; urgency=medium
+
+  * wb-gen-serial: fix overridable serial value (trim zero bytes)
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 01 Nov 2022 20:00:00 +0600
+
 wb-utils (3.7.0-wb105) stable; urgency=medium
 
   * wb-gen-serial: add overridable factory serial support

--- a/utils/bin/wb-gen-serial
+++ b/utils/bin/wb-gen-serial
@@ -63,7 +63,7 @@ def get_custom_serial():
     path = "/proc/device-tree/wirenboard/device-serial"
     if os.path.isfile(path):
         with open(path, "r") as f:
-            return f.read().strip()
+            return f.read().rstrip('\x00').strip()
     else:
         return None
 


### PR DESCRIPTION
Забыл про специфику чтения из `/proc/device-tree`, при тестировании всплыло, исправляю.