### PR TITLE
Bugfix/revert chat timeout

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.2.4) stable; urgency=medium
+
+  * wb-gsm: revert buggy v4.2.1 version
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 16 Nov 2022 01:22:56 +0300
+
 wb-utils (4.2.3) stable; urgency=medium
 
   * wb-prepare: fix failure in case of not-responding gsm modem (wb6x)

--- a/utils/lib/wb-gsm-common.sh
+++ b/utils/lib/wb-gsm-common.sh
@@ -73,7 +73,7 @@ function get_modem_usb_devices() {
 
 
 function test_connection() {
-    /usr/sbin/chat -t $2 -v ABORT "ERROR" ABORT "BUSY" "" AT OK "" > $1 < $1
+    /usr/sbin/chat -v   TIMEOUT $2 ABORT "ERROR" ABORT "BUSY" "" AT OK "" > $1 < $1
     RC=$?
     debug "(port:$1; timeout:$2) => $RC"
     echo $RC
@@ -493,8 +493,6 @@ function ensure_on() {
     fi
 
     if has_usb; then
-        debug "Waiting 10s before probing usb ports..."
-        sleep 10  # Some A7600Es got stuck, when probing usb connection just after poweron
         init_usb_connection
     fi
 


### PR DESCRIPTION
довольно давняя история с гонкой сети и hwconf, которую сначала решали не с той стороны
=> в мастер и в 2207 просочился плохо работающий wb-gsm.

в 2207 откатили изменения сразу; в мастере - так и болтался до текущего времени