### PR TITLE
Feature/check connection

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.3.0) stable; urgency=medium
+
+  * wb-gsm: add checks to test_connection
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Mon, 21 Nov 2022 11:41:12 +0300
+
 wb-utils (4.2.4) stable; urgency=medium
 
   * wb-gsm: revert buggy v4.2.1 version

--- a/utils/lib/wb-gsm-common.sh
+++ b/utils/lib/wb-gsm-common.sh
@@ -73,8 +73,14 @@ function get_modem_usb_devices() {
 
 
 function test_connection() {
-    /usr/sbin/chat -v   TIMEOUT $2 ABORT "ERROR" ABORT "BUSY" "" AT OK "" > $1 < $1
-    RC=$?
+    if ! /bin/fuser -s $1; then
+        /usr/bin/timeout --signal=SIGKILL --preserve-status $2 /usr/sbin/chat -v   TIMEOUT $2 ABORT "ERROR" ABORT "BUSY" "" AT OK "" > $1 < $1
+        RC=$?
+    else
+        debug "$1 is not free"
+        RC=1
+    fi
+
     debug "(port:$1; timeout:$2) => $RC"
     echo $RC
 }

--- a/utils/lib/wb-gsm-common.sh
+++ b/utils/lib/wb-gsm-common.sh
@@ -171,7 +171,7 @@ function init_usb_connection() {
 
         # A76x0E modems support ppp connection only via last port
         # => should be symlinked to /dev/ttyGSM (instead a first one)
-        # vizit https://mt-system.ru/sites/default/files/documents/moduli_a-serii_i_open_sdk.pdf for more info
+        # visit https://mt-system.ru/sites/default/files/documents/moduli_a-serii_i_open_sdk.pdf for more info
         local model_4g="a7600x"
         if is_model $model_4g; then
             debug "Got modem model $model_4g from dtso => reversing port symlinks"


### PR DESCRIPTION
в связи с последними событиями вокруг ppp (работает хрупко + пользователи ходят в порты своими watchdog-скриптами) - wb-gsm часто зависает на chat. Снаружи выглядит, как неподнимающийся ppp при перезагрузке, или зависание pon/poff ppp0

немного причесал:
- для связи внутри wb-gsm ходим в свободный от ppp порт
- порт должен быть chardev
- внешний таймаут на chat
- для 4g-модемов изменен порядок симлинков (там какая-то магия, что только последний порт работает с ppp)

результат: всё работает, как у нас на вики (можно оставлять настроечки по умолчанию); у меня ppp поднимается всегда (как ни дёргай в процессе); у пользователей вроде починилось