### PR TITLE
Fix make install with DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,9 @@ PREPARE_LIBDIR = $(LIBDIR)/prepare
 IMAGEUPDATE_POSTINST_DIR = $(DESTDIR)$(prefix)/lib/wb-image-update/postinst
 
 install:
-	install -m 0755 -d $(BINDIR) $(LIBDIR) $(SYSCONFDIR) $(PREPARE_LIBDIR) $(IMAGEUPDATE_POSTINST_DIR)
+	install -Dm0644 utils/etc_wb_env.sh $(SYSCONFDIR)/wb_env.sh
 
-	install -m 0644 utils/etc_wb_env.sh $(SYSCONFDIR)/wb_env.sh
-
-	install -m 0644 -t $(LIBDIR) \
+	install -Dm0644 -t $(LIBDIR) \
 		utils/lib/common.sh \
 		utils/lib/hardware.sh \
 		utils/lib/json.sh \
@@ -26,25 +24,25 @@ install:
 		utils/lib/wb_env_of.sh \
 		utils/lib/wb-gsm-common.sh
 
-	install -m 0755 -t $(LIBDIR) \
+	install -Dm0755 -t $(LIBDIR) \
 		utils/lib/wb-init.sh \
 		utils/lib/ensure-env-cache.sh
 
-	install -m 0655 -t $(PREPARE_LIBDIR) \
+	install -Dm0655 -t $(PREPARE_LIBDIR) \
 		utils/lib/prepare/partitions.sh \
 		utils/lib/prepare/vars.sh
 
-	install -m 0755 -t $(PREPARE_LIBDIR) \
+	install -Dm0755 -t $(PREPARE_LIBDIR) \
 		utils/lib/prepare/wb-prepare.sh
 
-	install -m 0755 -t $(BINDIR) \
+	install -Dm0755 -t $(BINDIR) \
 		utils/bin/wb-gen-serial \
 		utils/bin/wb-set-mac \
 		utils/bin/wb-gsm \
 		utils/bin/wb-watch-update \
 		utils/bin/wb-run-update
 
-	install -m 0755 -t $(IMAGEUPDATE_POSTINST_DIR) \
+	install -Dm0755 -t $(IMAGEUPDATE_POSTINST_DIR) \
 		utils/lib/wb-image-update/postinst/10update-u-boot
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,20 @@
-DESTDIR=/
-prefix=usr
-
+DESTDIR=
+prefix=/usr
+sysconfdir=/etc
 
 all:
 	@echo Nothing to do
 
-BINDIR = $(DESTDIR)/$(prefix)/bin
-LIBDIR = $(DESTDIR)/$(prefix)/lib/wb-utils
+BINDIR = $(DESTDIR)$(prefix)/bin
+LIBDIR = $(DESTDIR)$(prefix)/lib/wb-utils
+SYSCONFDIR = $(DESTDIR)$(sysconfdir)
 PREPARE_LIBDIR = $(LIBDIR)/prepare
-IMAGEUPDATE_POSTINST_DIR = $(DESTDIR)/$(prefix)/lib/wb-image-update/postinst
+IMAGEUPDATE_POSTINST_DIR = $(DESTDIR)$(prefix)/lib/wb-image-update/postinst
 
 install:
-	install -m 0755 -d $(BINDIR) $(LIBDIR) $(PREPARE_LIBDIR) $(IMAGEUPDATE_POSTINST_DIR)
+	install -m 0755 -d $(BINDIR) $(LIBDIR) $(SYSCONFDIR) $(PREPARE_LIBDIR) $(IMAGEUPDATE_POSTINST_DIR)
 
-	install -m 0644 utils/etc_wb_env.sh $(DESTDIR)/etc/wb_env.sh
+	install -m 0644 utils/etc_wb_env.sh $(SYSCONFDIR)/wb_env.sh
 
 	install -m 0644 -t $(LIBDIR) \
 		utils/lib/common.sh \

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.4.1) stable; urgency=medium
+
+  * Fix make install with DESTDIR
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 25 Nov 2022 10:18:15 +0400
+
 wb-utils (4.4.0) stable; urgency=medium
 
   * wb-gsm: add checks to test_connection


### PR DESCRIPTION
Before:
```sh
$ make install DESTDIR=out
install -m 0755 -d out/usr/bin out/usr/lib/wb-utils out/usr/lib/wb-utils/prepare out/usr/lib/wb-image-update/postinst
install -m 0644 utils/etc_wb_env.sh out/etc/wb_env.sh
install: cannot create regular file 'out/etc/wb_env.sh': No such file or directory
make: *** [install] Error 1
```

After:
```sh
$ make install DESTDIR=out
install -m 0755 -d out/usr/bin out/usr/lib/wb-utils out/etc out/usr/lib/wb-utils/prepare out/usr/lib/wb-image-update/postinst
install -m 0644 utils/etc_wb_env.sh out/etc/wb_env.sh
install -m 0644 -t out/usr/lib/wb-utils \
		utils/lib/common.sh \
		utils/lib/hardware.sh \
		utils/lib/json.sh \
		utils/lib/of.sh \
		utils/lib/wb_env_legacy.sh \
		utils/lib/wb_env.sh \
		utils/lib/wb_env_of.sh \
		utils/lib/wb-gsm-common.sh
install -m 0755 -t out/usr/lib/wb-utils \
		utils/lib/wb-init.sh \
		utils/lib/ensure-env-cache.sh
install -m 0655 -t out/usr/lib/wb-utils/prepare \
		utils/lib/prepare/partitions.sh \
		utils/lib/prepare/vars.sh
install -m 0755 -t out/usr/lib/wb-utils/prepare \
		utils/lib/prepare/wb-prepare.sh
install -m 0755 -t out/usr/bin \
		utils/bin/wb-gen-serial \
		utils/bin/wb-set-mac \
		utils/bin/wb-gsm \
		utils/bin/wb-watch-update \
		utils/bin/wb-run-update
install -m 0755 -t out/usr/lib/wb-image-update/postinst \
		utils/lib/wb-image-update/postinst/10update-u-boot
```