### PR TITLE
Fix wb-run-update

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.4.2) stable; urgency=medium
+
+  * Fix "die: command not found" error
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 09 Dec 2022 21:10:00 +0400
+
 wb-utils (4.4.1) stable; urgency=medium
 
   * Fix make install with DESTDIR

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -10,23 +10,6 @@ FLAGS=""
 DATA_PART="/dev/mmcblk0p6"
 DATA_LABEL="data"
 
-[[ $EUID != 0 ]] && die "Need root privileges to install update"
-
-while [[ -n "$1" ]]; do
-	case "$1" in
-		--*|-*)
-			FLAGS+="$1 "
-			;;
-		*)
-			[[ -n "$FIT" ]] && die "Bad arguments"
-			FIT=`readlink -f $1`
-			;;
-	esac
-	shift
-done
-
-[[ -n "$FIT" ]] || die "FIT $FIT not found"
-
 # Some handy functions, usable in install script
 flag_set() {
 	grep -- "--$1 " 2>&1 > /dev/null <<< "$FLAGS"
@@ -113,19 +96,6 @@ EOF
 		led_process
 		return $result
 	}
-
-	# check factory reset condition here and add flag in this case
-	case $FIT in
-		*FACTORYRESET*|*factoryreset*)
-			if flag_set no-confirm || prompt_update_factoryreset; then
-				echo -e "\nFactory reset is confirmed!\n"
-				FLAGS+="--factoryreset "
-			else
-				echo -e "\nFactory reset is NOT confirmed, reboot"
-				reboot -f
-			fi
-			;;
-	esac
 
 } || {
 	mqtt_status() {
@@ -217,6 +187,38 @@ fit_blob_verify_hash() {
 	[[ "$sha1_expected" == "$sha1_calculated" ]] &&
 		info "SHA1 hash of $name ok" ||
 		die "SHA1 of $name doesn't match (expected $sha1_expected, got $sha1_calculated)"
+}
+
+[[ $EUID != 0 ]] && die "Need root privileges to install update"
+
+while [[ -n "$1" ]]; do
+	case "$1" in
+		--*|-*)
+			FLAGS+="$1 "
+			;;
+		*)
+			[[ -n "$FIT" ]] && die "Bad arguments"
+			FIT=`readlink -f $1`
+			;;
+	esac
+	shift
+done
+
+[[ -f "$FIT" ]] || die "FIT $FIT not found"
+
+flag_set no-mqtt && {
+	# check factory reset condition here and add flag in this case
+	case $FIT in
+		*FACTORYRESET*|*factoryreset*)
+			if flag_set no-confirm || prompt_update_factoryreset; then
+				echo -e "\nFactory reset is confirmed!\n"
+				FLAGS+="--factoryreset "
+			else
+				echo -e "\nFactory reset is NOT confirmed, reboot"
+				reboot -f
+			fi
+			;;
+	esac
 }
 
 led_process


### PR DESCRIPTION
### Steps to reproduce

1. https://github.com/wirenboard/wb-utils/pull/6#discussion_r1045123328
```sh
# wb-run-update -h
/usr/bin/wb-run-update: line 28: die: command not found
fit_info: Missing node name
Usage: fit_info -f fit file -n node -p property
          -f ==> set fit file which is used'
          -n ==> set node name'
          -p ==> set property name'
fit_info: Missing node name
<...>
```

Fixed:
```sh
# wb-run-update -h
!!! FIT  not found
>>> Removing FIT
```

2. Correct check if file exists
```sh
# wb-run-update foo
fit_info: Can't open /mnt/data/root/foo: No such file or directory
fit_info: Can't open /mnt/data/root/foo: No such file or directory
fit_info: Can't open /mnt/data/root/foo: No such file or directory
fit_info: Can't open /mnt/data/root/foo: No such file or directory
fit_info: Can't open /mnt/data/root/foo: No such file or directory
fit_info: Can't open /mnt/data/root/foo: No such file or directory
fit_info: Can't open /mnt/data/root/foo: No such file or directory
fit_info: Can't open /mnt/data/root/foo: No such file or directory
fit_info: Can't open /mnt/data/root/foo: No such file or directory
<...>
```

Fixed:
```sh
# wb-run-update foo
!!! FIT /mnt/data/root/foo not found
>>> Removing FIT /mnt/data/root/foo
```