### PR TITLE
Do not set NetworkManager access point (wb-ap) SSID

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.4.5) stable; urgency=medium
+
+  * wb-prepare: do not set NetworkManager access point (wb-ap) SSID
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 28 Dec 2022 20:03:33 +0500
+
 wb-utils (4.4.4) stable; urgency=medium
 
   * wb-prepare: fix NetworkManager access point (wb-ap) SSID

--- a/utils/lib/prepare/wb-prepare.sh
+++ b/utils/lib/prepare/wb-prepare.sh
@@ -253,8 +253,6 @@ wb_fix_short_sn()
     log_action_msg "Setting internal Wi-Fi SSID to ${ssid}"
     sed -i "s/^ssid=.*/ssid=${ssid}/" $(readlink -f "/etc/hostapd.conf")
     log_end_msg $?
-
-    /usr/lib/wb-configs/fix_nm_ap_ssid.sh
 }
 
 # To run firstboot only once


### PR DESCRIPTION
It is now set by ExecStartPre of NetworkManager service