### PR TITLE
Update environment variables on modem setup

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.7.1) stable; urgency=medium
+
+  * Update environment variables on modem setup
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 09 Mar 2023 09:08:06 +0500
+
 wb-utils (4.7.0) stable; urgency=medium
 
   * wb-gsm: exit 1 for operations on modems, driven by ModemManager


### PR DESCRIPTION
ensure-env-cache.sh checks modification time of nodes in wirenboard/gsm. Modems with USB update nodes of alias/wbc_modem. So ensure-env-cache.sh doesn't update wb_env.cache and environment variables. Add alias/wbc_modem to checked nodes