### PR TITLE
wb-gsm: add is-acquired-by-pppd workaround

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.7.2) stable; urgency=medium
+
+  * wb-gsm: add is-acquired-by-pppd workaround
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 16 Mar 2023 22:21:36 +0300
+
 wb-utils (4.7.1) stable; urgency=medium
 
   * Update environment variables on modem setup

--- a/utils/lib/wb-gsm-common.sh
+++ b/utils/lib/wb-gsm-common.sh
@@ -107,17 +107,27 @@ function check_is_not_driven_by_mm() {
     done
 }
 
+function is_acquired_by_pppd() {
+    # sometimes, when launched from init-section of pppd, serial port could be already acquired by pppd
+    # we assume, if parent's ppid is in fuser's output, this is this case
+    echo $(/bin/fuser $1 2>&1) | grep -q "$(ps -o ppid= -p $PPID)"
+}
 
 function test_connection() {
     if ! /bin/fuser -s $1; then
         /usr/bin/timeout --signal=SIGKILL --preserve-status $2 /usr/sbin/chat -v   TIMEOUT $2 ABORT "ERROR" ABORT "BUSY" "" AT OK "" > $1 < $1
         RC=$?
     else
-        debug "$1 is not free"
-        RC=1
+        if is_acquired_by_pppd $1; then
+            debug "$1 seems to be acquired by pppd; treating as free"
+            RC=0
+        else
+            debug "$1 is not free"
+            RC=1
+        fi
     fi
 
-    debug "(port:$1; timeout:$2) => $RC"
+    debug "(port:$1($(readlink -f $1)); timeout:$2) => $RC"
     echo $RC
 }
 


### PR DESCRIPTION
играясь с модемами, @webconn обнаружил странное поведение, когда MM отбирает порт у pppd


pppd запускает wb-gsm из init-секции; если что-то случилось (MM стал воевать с pppd) - pppd пытается переподключиться, и модемный порт остаётся занятым pppd -> это видит wb-gsm (и ему это не нравится) -> wb-gsm говорит, что всё сломалось, вырубает питание и удаляет симлинк /dev/ttyGSM -> pppd видит, что порта нет и остаётся его ждать

посовещавшись, решили сделать наименее инвазивный костыль на уровне wb-gsm (т.к. больше - особо негде)
![2023-03-17_10-44-06](https://user-images.githubusercontent.com/25829054/225854274-e1fffe28-7104-4692-b12d-2c9ccd34b5a2.png)
