### PR TITLE
fix fwupdate-service stuck on unsuccessful update

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.8.1) stable; urgency=medium
+
+  * Fix fwupdate-service stuck on unsuccessful update
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 22 Mar 2023 22:55:34 +0300
+
 wb-utils (4.8.0) stable; urgency=medium
 
   * wb-gsm: stop MM if launched from script; warn user otherwise

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -130,8 +130,8 @@ die() {
 	local msg=${*:-"Failed"}
 	>&2 echo "!!! $msg"
 	mqtt_status "ERROR $msg"
-	mqtt_status "IDLE"
 	rm_fit
+	mqtt_status "IDLE"
 	[[ $? == 0 ]] && exit 1 || exit $?
 }
 
@@ -174,7 +174,7 @@ fit_blob_verify_hash() {
 	local sha1_expected=`fit_blob_hash $name`
 
 	info "Checking SHA1 hash of $name"
-	
+
 	local blob_size=`fit_blob_size rootfs`
 	local tmp=`mktemp -p $TMPDIR`
 	(

--- a/utils/bin/wb-watch-update
+++ b/utils/bin/wb-watch-update
@@ -65,6 +65,7 @@ while read EVENT_DIR EVENT_TYPE EVENT_FILE; do
 		mqtt_status "ERROR $msg"
 		mqtt_status "IDLE"
 		rm -f $FIT
+		LAST_FIT=""
 		continue
 	}
 
@@ -76,6 +77,10 @@ while read EVENT_DIR EVENT_TYPE EVENT_FILE; do
 	mqtt_log "$msg"
 
 	wb-run-update $FIT 2>&1 | tee -a "$UPDATE_LOG" | mqtt_log_pipe
+	if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
+		FIT=""
+		LAST_FIT=""
+	fi
 
 	rm -f $FIT
 done


### PR DESCRIPTION
тыкая стенд тестирования релизов, обнаружил, что при неудачном обновлении из webui,
![2023-03-22_22-57-44](https://user-images.githubusercontent.com/25829054/227024644-e463b065-e205-4d67-bd02-759b0fef6f14.png)
 второй раз залить fit не получается (до перезапуска wb-watch-update).
 
Раздебажил, починил