### PR TITLE
wb-gsm: add recommendation about ModemManager to logs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.8.2) stable; urgency=medium
+
+  * wb-gsm: add recommendation about ModemManager to logs
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 30 Mar 2023 23:43:19 +0300
+
 wb-utils (4.8.1) stable; urgency=medium
 
   * Fix fwupdate-service stuck on unsuccessful update

--- a/utils/lib/wb-gsm-common.sh
+++ b/utils/lib/wb-gsm-common.sh
@@ -119,9 +119,10 @@ function handle_mm() {
 
     local service_name="ModemManager"
 
-    if systemctl is-active --quiet service $service_name; then
+    if is_driven_by_mm; then
+        debug "wb-gsm is becoming deprecated. Use $service_name instead"
 
-        if is_driven_by_mm; then
+        if systemctl is-active --quiet service $service_name; then
 
             if is_called_from_terminal; then
                 >&2 cat <<EOF


### PR DESCRIPTION
Женя хотел, чтобы wb-gsm напоминал в логах о том, что есть ModemManager