### PR TITLE
Single rootfs scheme support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,10 @@ MASS_STORAGE_FNAME = build_scripts/mass_storage.img
 MASS_STORAGE_CONTENT_DIR = utils/lib/wb-usb-otg/mass_storage_contents
 NM_DISPATCHER_DIR = $(DESTDIR)$(prefix)/lib/NetworkManager/dispatcher.d
 PREPARE_LIBDIR = $(LIBDIR)/prepare
-IMAGEUPDATE_POSTINST_DIR = $(DESTDIR)$(prefix)/lib/wb-image-update/postinst
+
+IMAGEUPDATE_DIR=$(DESTDIR)$(prefix)/lib/wb-image-update
+IMAGEUPDATE_POSTINST_DIR = $(IMAGEUPDATE_DIR)/postinst
+FIT_FILES_DIR=$(IMAGEUPDATE_DIR)/fit
 
 build_mass_storage: export wb_ipaddr := http://10.200.200.1
 build_mass_storage:
@@ -54,6 +57,9 @@ install: build_mass_storage
 
 	install -Dm0755 -t $(IMAGEUPDATE_POSTINST_DIR) \
 		utils/lib/wb-image-update/postinst/10update-u-boot
+
+	install -Dm0755 -t $(FIT_FILES_DIR) \
+		utils/lib/wb-image-update/fit/install_update.sh
 
 	install -Dm0755 -t $(USBOTGDIR) \
 		utils/lib/wb-usb-otg/wb-usb-otg-common.sh \

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ install: build_mass_storage
 		utils/lib/wb-image-update/postinst/10update-u-boot
 
 	install -Dm0755 -t $(FIT_FILES_DIR) \
+		utils/lib/wb-image-update/fit/build.sh \
 		utils/lib/wb-image-update/fit/install_update.sh
 
 	install -Dm0755 -t $(USBOTGDIR) \

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ wb-utils (4.9.0) stable; urgency=medium
 
   * move install_update.sh script for FIT images to this package
   * add rootfs repartition on factory reset feature
+  * add single rootfs update scheme support
 
  -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 22 Mar 2023 15:11:31 +0600
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-utils (4.9.0) stable; urgency=medium
+
+  * move install_update.sh script for FIT images to this package
+  * add rootfs repartition on factory reset feature
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 22 Mar 2023 15:11:31 +0600
+
 wb-utils (4.8.2) stable; urgency=medium
 
   * wb-gsm: add recommendation about ModemManager to logs

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: https://github.com/wirenboard/wb-utils
 Package: wb-utils
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, lsb-base (>= 4.1), u-boot-tools-wb (>= 2015.07+wb-3), inotify-tools, pv, jq,
-         nginx-extras, python3-wb-common (>= 2.0.0~~), wb-configs (>= 3.13.1~~), util-linux,
+         nginx-extras, python3-wb-common (>= 2.0.0~~), wb-configs (>= 3.15.0~~), util-linux,
          linux-image-wb2 (>= 4.9+wb20180808183130) | linux-image-wb6 (>= 5.10.35-wb108~~) | linux-image-wb7 (>= 5.10.35-wb130~~),
          device-tree-compiler, parted, rsync, systemd (>= 243)
 Conflicts: wb-configs (<< 1.69.4)

--- a/debian/control
+++ b/debian/control
@@ -13,5 +13,5 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, lsb-base (>= 4.1), u-boot-tools-wb 
          linux-image-wb2 (>= 4.9+wb20180808183130) | linux-image-wb6 (>= 5.10.35-wb108~~) | linux-image-wb7 (>= 5.10.35-wb130~~),
          device-tree-compiler, parted, rsync, systemd (>= 243)
 Conflicts: wb-configs (<< 1.69.4)
-Breaks: wb-homa-ism-radio (<< 1.17.2), wb-rules-system (<< 1.6.1), wb-mqtt-serial (<< 1.47.2), wb-mqtt-homeui (<< 1.7.1)
+Breaks: wb-homa-ism-radio (<< 1.17.2), wb-rules-system (<< 1.6.1), wb-mqtt-serial (<< 1.47.2), wb-mqtt-homeui (<< 1.7.1), u-boot-wb7 (<< 2:2021.10+wb1.5.0~~)
 Description: Wiren Board command-line utils

--- a/debian/postinst
+++ b/debian/postinst
@@ -2,5 +2,10 @@
 set -e
 #DEBHELPER#
 
+if [[ -e "/usr/sbin/policy-rc.d" ]] && [[ "$(cat /usr/sbin/policy-rc.d)" == "exit 101" ]]; then
+    echo "rootfs building mode, preparing FIT install script"
+    /usr/lib/wb-image-update/fit/build.sh
+fi
+
 /usr/lib/wb-utils/prepare/wb-prepare.sh fix_hosts
 exit 0

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -2,6 +2,14 @@
 #set -e
 #set -x
 
+# This script will be greatly simplified in the future, so please
+#
+#   DO NOT ADD ANY NEW FEATURES HERE!
+#
+# A great place for the new update features is
+# utils/lib/wb-image-update/fit/install_image.sh file
+# in this repository.
+
 TMPDIR="/dev/shm"
 FIT=""
 FLAGS=""
@@ -129,8 +137,8 @@ die() {
 	local ret=$?
 	local msg=${*:-"Failed"}
 	>&2 echo "!!! $msg"
-	mqtt_status "ERROR $msg"
 	rm_fit
+	mqtt_status "ERROR $msg"
 	mqtt_status "IDLE"
 	[[ $? == 0 ]] && exit 1 || exit $?
 }

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -197,6 +197,36 @@ fit_blob_verify_hash() {
 		die "SHA1 of $name doesn't match (expected $sha1_expected, got $sha1_calculated)"
 }
 
+disk_layout_is_ab() {
+    local ROOTFS1_PART=/dev/mmcblk0p2
+    local ROOTFS2_PART=/dev/mmcblk0p3
+    [ "$(blockdev --getsz "$ROOTFS1_PART")" -eq "$(blockdev --getsz "$ROOTFS2_PART")" ]
+}
+
+fw_compatible() {
+    local feature="$1"
+    local fw_compat
+    fw_compat=$(fit_prop_string / firmware-compatible)
+
+    case "$fw_compat" in
+        *"+$feature "*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+check_firmware_compatible() {
+    if flag_set force-fw-compatible; then
+        info "Firmware compatibility check skipped"
+        return
+    fi
+
+    if ! disk_layout_is_ab && ! fw_compatible "single-rootfs"; then
+        die "Firmware is not compatible with single-rootfs layout"
+    fi
+
+    info "Firmware seems to be compatible with this controller"
+}
+
 [[ $EUID != 0 ]] && die "Need root privileges to install update"
 
 while [[ -n "$1" ]]; do
@@ -272,6 +302,8 @@ flag_set factoryreset && {
 		info "Factory reset is now supported only from initramfs environment"
 	fi
 }
+
+check_firmware_compatible
 
 info "Extracting install script"
 INSTALL_SCRIPT=`mktemp -p $TMPDIR`

--- a/utils/bin/wb-watch-update
+++ b/utils/bin/wb-watch-update
@@ -1,10 +1,16 @@
 #!/bin/bash
+# vim: set noexpandtab:
 #set -x
-WATCH_DIR="/var/www/uploads"
 UPDATE_FIT_END_SIGNATURE="__WB_UPDATE_FIT_END__"
 UPDATE_LOG="/var/log/update.log"
 
 PID_FILE="/var/run/wb-watch-update.pid"
+
+AB_WATCH_DIR="/var/www/uploads"
+SINGLE_WATCH_DIR="/mnt/data/.wb-update"
+
+WATCH_DIR_SYMLINK="/var/run/wb-watch-update.dir"
+
 cleanup() {
 	[[ -f "$PID_FILE" ]] && kill `cat "$PID_FILE"` 2>/dev/null
 	rm -f "$PID_FILE"
@@ -28,6 +34,10 @@ mqtt_status() {
 	mosquitto_pub -r -t /firmware/status -m "$*"
 }
 
+mqtt_log_retain() {
+	mosquitto_pub -t /firmware/log -m "$*" -r
+}
+
 mqtt_log() {
 	mosquitto_pub -t /firmware/log -m "$*"
 }
@@ -35,6 +45,55 @@ mqtt_log() {
 mqtt_log_pipe() {
 	mosquitto_pub -t /firmware/log -l
 }
+
+mqtt_log_reset() {
+	mosquitto_pub -t /firmware/log -m "" -r
+}
+
+DEFAULT_STATUS="IDLE"
+
+maybe_publish_singlemode_update_status() {
+	local logfile="$SINGLE_WATCH_DIR/state/update.log"
+	local statusfile="$SINGLE_WATCH_DIR/state/update.status"
+
+	if [ -e "$statusfile" ]; then
+		if [ -e "$logfile" ]; then
+			log "Seems like update just have been done, printing logs and saving it in retained"
+			log "Saved status: $(cat "$statusfile")"
+			log "Please reload page if there is no 'Done' button"
+
+			mqtt_log_retain "$({
+				echo ">>> Installation logs:"
+				sed -e 's/^INFO /%%% /' -e 's/^REBOOT.*$/%%% (reboot)/' < "$logfile"
+			})"
+		fi
+
+		# This is a combined status example. It should not be used anywhere
+		# but in this tool in order to preseve compatibility.
+		#
+		# See app/scripts/react-directives/firmware-update/store.js in homeui
+		# to know more about it.
+
+		DEFAULT_STATUS="$({
+			cat "$statusfile"
+			echo -ne "\nIDLE"
+		})"
+		rm -rf "$statusfile"
+	fi
+}
+
+if [ "$(blockdev --getsz /dev/mmcblk0p2)" -ne "$(blockdev --getsz /dev/mmcblk0p3)" ]; then
+	log "using single rootfs update mode"
+	WATCH_DIR="$SINGLE_WATCH_DIR"
+else
+	log "using legacy A/B update mode"
+	WATCH_DIR="$AB_WATCH_DIR"
+fi
+
+maybe_publish_singlemode_update_status
+mkdir -p "$WATCH_DIR"
+chown www-data:www-data "$WATCH_DIR"
+ln -snf "$WATCH_DIR" "$WATCH_DIR_SYMLINK"
 
 LAST_FIT=''
 
@@ -47,7 +106,7 @@ LAST_FIT=''
 trap cleanup EXIT
 
 # wait for mosquitto to open socket
-while ! mqtt_status "IDLE"; do
+while ! mqtt_status "$DEFAULT_STATUS"; do
     sleep 1
 done
 
@@ -57,6 +116,8 @@ while read EVENT_DIR EVENT_TYPE EVENT_FILE; do
 	# Prevent endless loop
 	[[ "$FIT" != "$LAST_FIT" ]] || continue
 	LAST_FIT=$FIT
+
+	mqtt_log_reset
 
 	# Ensure that image was received completely
 	check_fully_received $FIT || {
@@ -82,6 +143,11 @@ while read EVENT_DIR EVENT_TYPE EVENT_FILE; do
 		LAST_FIT=""
 	fi
 
+	if [ -e "$SINGLE_WATCH_DIR/state/update.status" ] ; then
+		log "Exiting wb-watch-update, restart is required by FIT"
+		exit 0
+	fi
+	
 	rm -f $FIT
 done
 }

--- a/utils/bin/wb-watch-update
+++ b/utils/bin/wb-watch-update
@@ -115,7 +115,7 @@ while read EVENT_DIR EVENT_TYPE EVENT_FILE; do
 
 	# skip install_update.flags file event, it may be used for debugging
 	case "$FIT" in
-	*install_update.flags)
+	*install_update.*|)
 		continue
 		;;
 	esac

--- a/utils/bin/wb-watch-update
+++ b/utils/bin/wb-watch-update
@@ -101,6 +101,7 @@ LAST_FIT=''
 	echo "$BASHPID" > "$PID_FILE"
 	2>/dev/null exec inotifywait -m -r \
 		--exclude $WATCH_DIR/state/ \
+		--exclude $WATCH_DIR/install_update.flags \
 		--event close_write $WATCH_DIR/ \
 ) | {
 trap cleanup EXIT
@@ -131,7 +132,7 @@ while read EVENT_DIR EVENT_TYPE EVENT_FILE; do
 	}
 
 	# Remove old updates, we won't run it anyway
-	cleanup_watch_dir -not -name ${EVENT_FILE}
+	cleanup_watch_dir -not -name ${EVENT_FILE} -not -name install_update.flags
 
 	msg="Received good update FIT $FIT, starting update"
 	log "$msg"

--- a/utils/bin/wb-watch-update
+++ b/utils/bin/wb-watch-update
@@ -101,7 +101,6 @@ LAST_FIT=''
 	echo "$BASHPID" > "$PID_FILE"
 	2>/dev/null exec inotifywait -m -r \
 		--exclude $WATCH_DIR/state/ \
-		--exclude $WATCH_DIR/install_update.flags \
 		--event close_write $WATCH_DIR/ \
 ) | {
 trap cleanup EXIT
@@ -113,6 +112,13 @@ done
 
 while read EVENT_DIR EVENT_TYPE EVENT_FILE; do
 	FIT="${EVENT_DIR}${EVENT_FILE}"
+
+	# skip install_update.flags file event, it may be used for debugging
+	case "$FIT" in
+	*install_update.flags)
+		continue
+		;;
+	esac
 
 	# Prevent endless loop
 	[[ "$FIT" != "$LAST_FIT" ]] || continue

--- a/utils/bin/wb-watch-update
+++ b/utils/bin/wb-watch-update
@@ -139,7 +139,7 @@ while read EVENT_DIR EVENT_TYPE EVENT_FILE; do
 	}
 
 	# Remove old updates, we won't run it anyway
-	cleanup_watch_dir -not -name ${EVENT_FILE} -not -name install_update.flags
+	cleanup_watch_dir -not -name ${EVENT_FILE} -not -name 'install_update.*'
 
 	msg="Received good update FIT $FIT, starting update"
 	log "$msg"

--- a/utils/bin/wb-watch-update
+++ b/utils/bin/wb-watch-update
@@ -122,6 +122,7 @@ while read EVENT_DIR EVENT_TYPE EVENT_FILE; do
 
 	# Prevent endless loop
 	[[ "$FIT" != "$LAST_FIT" ]] || continue
+	[[ -e "$FIT" ]] || continue
 	LAST_FIT=$FIT
 
 	mqtt_log_reset

--- a/utils/lib/wb-image-update/fit/build.sh
+++ b/utils/lib/wb-image-update/fit/build.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 set -e
 
-# This script runs on image creation stage and builds install_update.sh
+# This script runs during rootfs build.
+#
+# It collects all the files (and their binary deps) needed for install_update.sh
+# (such as resize2fs and e2fsck) which are not present in a bootlet.
+#
+# These files are archived in /var/lib/wb-image-update/deps.tar.gz.
+# install_update.sh extracts this archive from rootfs tarball and
+# use its contents as chroot environment to run resize2fs and e2fsck.
+#
+# Image builder script takes install_update.sh from /var/lib/wb-image-update
+# (so it may be modified during rootfs build), so this script puts it there too.
 
 if ! which policy-rc.d; then
     echo "You don't need this, please go away"

--- a/utils/lib/wb-image-update/fit/build.sh
+++ b/utils/lib/wb-image-update/fit/build.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -e
+
+# This script runs on image creation stage and builds install_update.sh
+
+if ! which policy-rc.d; then
+    echo "You don't need this, please go away"
+    exit 1
+fi
+
+BUILDDIR="$(mktemp -d)"
+
+cleanup() {
+    rm -rf "$BUILDDIR"
+}
+
+trap cleanup EXIT 
+
+install_dir() {
+        echo "dir $1"
+        mkdir -p "$BUILDDIR/$1"
+}
+
+install_file() {
+        local src="$1"
+        local dst="$2"
+
+        local dstdir
+        dstdir=$(dirname "$dst")
+        [[ -d "$BUILDDIR/$dstdir" ]] || install_dir "$dstdir"
+
+        echo "file $dst <- $src"
+        cp "$src" "$BUILDDIR/$dst"
+}
+
+install_from_rootfs() {
+        local src="$1"
+        local dst="$2"
+
+        [[ -z "$dst" ]] && {
+                dst="$src"
+                shift
+        }
+        install_file "$ROOTFS/$src" "$dst"
+
+        # If file is executable, need to get its shared lib dependencies too
+        if [[ -x "$ROOTFS/$src" ]]; then
+                ldd "$src" |
+                sed -rn 's#[^/]*(/[^ ]*).*#\1#p' |
+                while read -r lib; do
+                        [[ -e "$BUILDDIR/$lib" ]] || install_from_rootfs "$lib"
+                done
+        fi
+}
+
+FROM_ROOTFS=(
+    /sbin/resize2fs
+    /sbin/e2undo
+    /sbin/e2fsck
+    /sbin/e4defrag
+)
+
+for file in "${FROM_ROOTFS[@]}"; do
+    install_from_rootfs "$file"
+done
+
+mkdir -p /var/lib/wb-image-update
+
+cp /usr/lib/wb-image-update/fit/install_update.sh /var/lib/wb-image-update/install_update.sh
+cd "$BUILDDIR" && tar cvzf /var/lib/wb-image-update/deps.tar.gz .

--- a/utils/lib/wb-image-update/fit/build.sh
+++ b/utils/lib/wb-image-update/fit/build.sh
@@ -8,6 +8,14 @@ if ! which policy-rc.d; then
     exit 1
 fi
 
+. /usr/lib/wb-utils/wb_env.sh
+wb_source "of"
+
+if ! of_machine_match "wirenboard,wirenboard-720"; then
+    echo "Single rootfs scheme is not supported on this target, skipping install_update.sh build"
+    exit 0
+fi
+
 BUILDDIR="$(mktemp -d)"
 
 cleanup() {

--- a/utils/lib/wb-image-update/fit/build.sh
+++ b/utils/lib/wb-image-update/fit/build.sh
@@ -68,3 +68,5 @@ mkdir -p /var/lib/wb-image-update
 
 cp /usr/lib/wb-image-update/fit/install_update.sh /var/lib/wb-image-update/install_update.sh
 cd "$BUILDDIR" && tar cvzf /var/lib/wb-image-update/deps.tar.gz .
+
+echo "+single-rootfs " > /var/lib/wb-image-update/firmware-compatible

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -100,10 +100,11 @@ prepare_env() {
 		FLAGS+=" $(cat "$flags_file") "
 	fi
 
+    UPDATE_STATUS_FILE="$UPDATE_DIR/state/update.status"
+    UPDATE_LOG_FILE="$UPDATE_DIR/state/update.log"
+
     if flag_set from-webupdate; then
         info "Web UI-triggered update detected, forwarding logs and status to files"
-        UPDATE_STATUS_FILE="$UPDATE_DIR/state/update.status"
-        UPDATE_LOG_FILE="$UPDATE_DIR/state/update.log"
 
         mqtt_status() {
             echo "$*" >> "$UPDATE_LOG_FILE"
@@ -611,11 +612,12 @@ update_after_reboot() {
 
     # write error note by default in the update status file,
     # it will be overwritten if update script is started properly after reboot
-    echo "ERROR Nothing happened after reboot, maybe U-boot is outdated?" > "$UPDATE_DIR/state/update.status"
+    echo "ERROR Nothing happened after reboot, maybe U-boot is outdated?" > "$UPDATE_STATUS_FILE"
 
     fw_setenv wb_webupd 1
 
-    maybe_reboot
+    trap_add maybe_reboot EXIT
+    exit 0
 }
 
 #---------------------------------------- main ----------------------------------------
@@ -692,4 +694,4 @@ info "Done!"
 rm_fit
 led_success || true
 
-maybe_reboot
+trap_add maybe_reboot EXIT

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -40,6 +40,10 @@ fatal() {
     local retcode=$?
     local msg="$*"
 
+    if [ "$retcode" -eq 0 ]; then
+        retcode=1
+    fi
+
     if flag_set from-initramfs; then
         >&2 echo "!!! $msg"
         if flag_set from-webupdate; then
@@ -99,8 +103,9 @@ prepare_env() {
     if [ -e "$flags_file" ]; then
         ADDITIONAL_FLAGS=$(cat "$flags_file")
         info "Using flags from $flags_file: $ADDITIONAL_FLAGS"
-        FLAGS="$FLAGS $(ADDITIONAL_FLAGS) "
+        FLAGS="$FLAGS $ADDITIONAL_FLAGS "
     fi
+
 
     UPDATE_STATUS_FILE="$UPDATE_DIR/state/update.status"
     UPDATE_LOG_FILE="$UPDATE_DIR/state/update.log"
@@ -649,7 +654,12 @@ if ! flag_set from-initramfs; then
     if ! disk_layout_is_ab; then
         update_after_reboot
     fi
+else
+    if flag_set fail-in-bootlet; then
+        fatal "Update failed by request"
+    fi
 fi
+
 
 if flag_set "factoryreset" && ! flag_set "no-repartition"; then
     maybe_repartition

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -573,6 +573,18 @@ run_postinst() {
     umount "$ROOTFS_MNT/sys"
 }
 
+copy_this_fit_to_factory() {
+    local mnt
+    mnt=$(mktemp -d)
+
+    info "Copying $FIT to factory default location as requested"
+
+    mount "$DATA_PART" "$mnt" || fatal "Unable to mount data partition"
+    cp "$FIT" "$mnt/.wb-restore/factoryreset.fit"
+    umount "$mnt" || true
+    sync; sync
+}
+
 maybe_reboot() {
     if ! flag_set no-reboot; then
         info "Reboot system"
@@ -666,6 +678,10 @@ fi
 
 if ! flag_set no-postinst; then
     run_postinst "$MNT"
+fi
+
+if flag_set copy-to-factory; then
+    copy_this_fit_to_factory
 fi
 
 info "Switching to new rootfs"

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -1,0 +1,226 @@
+#!/bin/bash
+
+set -e
+
+# FIXME: transitional definitions which are being moved to wb-run-update
+HIDDENFS_PART=/dev/mmcblk0p1
+HIDDENFS_OFFSET=$((8192*512))  # 8192 blocks of 512 bytes
+DEVCERT_NAME="device.crt.pem"
+INTERM_NAME="intermediate.crt.pem"
+ROOTFS_CERT_PATH="/etc/ssl/certs/device_bundle.crt.pem"
+
+type fit_prop_string 2>/dev/null | grep -q 'shell function' || {
+    fit_prop_string() {
+        fit_prop "$@" | tr -d '\0'
+    }
+}
+
+type mkfs_ext4 2>/dev/null | grep -q 'shell function' || {
+    mkfs_ext4() {
+        local part=$1
+        local label=$2
+
+        yes | mkfs.ext4 -L "$label" -E stride=2,stripe-width=1024 -b 4096 "$part"
+    }
+}
+
+
+check_compatible() {
+	local fit_compat=`fit_prop_string / compatible`
+	[[ -z "$fit_compat" || "$fit_compat" == "unknown" ]] && return 0
+	for compat in `tr < /proc/device-tree/compatible  '\000' '\n'`; do
+		[[ "$fit_compat" == "$compat" ]] && return 0
+	done
+	return 1
+}
+
+if flag_set "force-compatible"; then
+	info "WARNING: Don't check compatibility. I hope you know what you're doing..."
+else
+	check_compatible || die "This update is incompatible with this device"
+fi
+
+fit_blob_verify_hash rootfs
+
+info "Installing firmware update"
+
+MNT="$TMPDIR/rootfs"
+ACTUAL_DEB_RELEASE=""
+
+ROOT_DEV='mmcblk0'
+if [[ -e "/dev/root" ]]; then
+	PART=`readlink /dev/root`
+	PART=${PART##*${ROOT_DEV}p}
+else
+	info "Getting mmcpart from U-Boot environment"
+	PART=$(fw_printenv mmcpart | sed 's/.*=//') || PART=""
+fi
+
+case "$PART" in
+	2)
+		PART=3
+		PART_NOW=2
+		PARTLABEL=rootfs1
+		;;
+	3)
+		PART=2
+		PART_NOW=3
+		PARTLABEL=rootfs0
+		;;
+	*)
+		flag_set from-initramfs && {
+			info "Update is started from initramfs and unable to determine active rootfs partition, will overwrite rootfs0"
+			PART=2
+			PART_NOW=3
+			PARTLABEL=rootfs0
+		} || {
+			die "Unable to determine second rootfs partition (current is $PART)"
+		}
+		;;
+esac
+ROOT_PART=/dev/${ROOT_DEV}p${PART}
+info "Will install to $ROOT_PART"
+
+rm -rf "$MNT" && mkdir "$MNT" || die "Unable to create mountpoint $MNT"
+
+flag_set "from-initramfs" && {
+    actual_rootfs=/dev/${ROOT_DEV}p${PART_NOW}
+    info "Check if partition table is correct"
+    [[ -e $ROOT_PART ]] && [[ -e $actual_rootfs ]] || {
+        die "rootfs partition doesn't exist, looks like partitions table is broken. Give up."
+    }
+    info "Temporarily mount actual rootfs $actual_rootfs to check os-release"
+    mount -t ext4 $actual_rootfs $MNT 2>&1 >/dev/null && {
+        sync
+        ACTUAL_DEB_RELEASE="$(MNT="$MNT" bash -c 'source "$MNT/etc/os-release"; echo $VERSION_CODENAME')"
+        umount -f $actual_rootfs 2>&1 >/dev/null || true
+    } || true
+}
+
+# determine if new partition is unformatted
+mount -t ext4 $ROOT_PART $MNT 2>&1 >/dev/null || {
+    info "Unable to mount root partition, formatting $ROOT_PART"
+    mkfs_ext4 $ROOT_PART $PARTLABEL || die "mkfs.ext4 failed"
+}
+
+umount -f $ROOT_PART 2>&1 >/dev/null || true # just for sure
+
+info "Mounting $ROOT_PART at $MNT"
+mount -t ext4 "$ROOT_PART" "$MNT" 2>&1 >/dev/null|| die "Unable to mount root filesystem"
+
+[[ -z "$ACTUAL_DEB_RELEASE" ]] && ACTUAL_DEB_RELEASE="$(bash -c 'source "/etc/os-release"; echo $VERSION_CODENAME')"
+upcoming_deb_release="$(fit_prop_string / release-target | sed 's/wb[[:digit:]]\+\///')"
+info "Debian: $ACTUAL_DEB_RELEASE -> $upcoming_deb_release"
+if [ "$ACTUAL_DEB_RELEASE" = "bullseye" ] && [ "$upcoming_deb_release" = "stretch" ]; then
+    if ! flag_set factoryreset; then
+        >&2 cat <<EOF
+##############################################################################
+
+    ROLLBACK FROM $ACTUAL_DEB_RELEASE TO $upcoming_deb_release REQUESTED
+
+                    Due to major Debian release changes,
+                this operation is allowed only via FACTORYRESET.
+
+    Rename .fit file to "wbX_update_FACTORYRESET.fit" ->
+    put renamed file to usb-drive ->
+    ensure, there is only one .fit file on usb-drive ->
+    insert usb-drive to controller and reboot ->
+    follow further factoryreset instructions.
+
+##############################################################################
+EOF
+        if flag_set from-initramfs; then
+            led_failure
+            bash -c 'source /lib/libupdate.sh; buzzer_init; buzzer_on; sleep 1; buzzer_off'
+            info "Rebooting..."
+            reboot -f
+        else
+            die "Aborting..."
+        fi
+    fi
+fi
+
+info "Cleaning up $ROOT_PART"
+rm -rf /tmp/empty && mkdir /tmp/empty
+if which rsync >/dev/null; then
+    info "Cleaning up using rsync"
+    rsync -a --delete /tmp/empty/ $MNT || die "Failed to cleanup rootfs"
+else
+    info "Can't find rsync, cleaning up using rm -rf (may be slower)"
+    rm -rf $MNT/..?* $MNT/.[!.]* $MNT/* || die "Failed to cleanup rootfs"
+fi
+
+info "Extracting files to new rootfs"
+pushd "$MNT"
+blob_size=`fit_blob_size rootfs`
+(
+	echo 0
+	fit_blob_data rootfs | pv -n -s "$blob_size" | tar xzp || die "Failed to extract rootfs"
+) 2>&1 | mqtt_progress "$x"
+popd
+
+if ! flag_set no-certificates; then
+    info "Recovering device certificates"
+    HIDDENFS_MNT=$TMPDIR/hiddenfs
+    mkdir -p $HIDDENFS_MNT
+
+    # make loop device
+    LO_DEVICE=`losetup -f`
+    losetup -r -o $HIDDENFS_OFFSET $LO_DEVICE $HIDDENFS_PART ||
+        die "Failed to add loopback device"
+
+    if mount $LO_DEVICE $HIDDENFS_MNT 2>&1 >/dev/null; then
+        cat $HIDDENFS_MNT/$INTERM_NAME $HIDDENFS_MNT/$DEVCERT_NAME > $MNT/$ROOTFS_CERT_PATH ||
+            info "WARNING: Failed to copy device certificate bundle into new rootfs. Please report it to info@contactless.ru"
+        umount $HIDDENFS_MNT
+        sync
+    else
+        info "WARNING: Failed to find certificates of device. Please report it to info@contactless.ru"
+    fi
+fi
+
+if ! flag_set no-postinst; then
+    info "Mount /dev, /proc and /sys to rootfs"
+    mount -o bind /dev "$MNT/dev"
+    mount -o bind /proc "$MNT/proc"
+    mount -o bind /sys "$MNT/sys"
+
+    POSTINST_DIR="$MNT/usr/lib/wb-image-update/postinst/"
+    if [[ -d "$POSTINST_DIR" ]]; then
+        info "Running post-install scripts"
+
+        POSTINST_FILES="$(find "$POSTINST_DIR" -maxdepth 1 -type f | sort)"
+        for file in $POSTINST_FILES; do
+            info "> Processing $file"
+            FIT="$FIT" "$file" "$MNT" "$FLAGS" || true
+        done
+    fi
+
+    info "Unmounting /dev, /proc and /sys from rootfs"
+    umount "$MNT/dev"
+    umount "$MNT/proc"
+    umount "$MNT/sys"
+fi
+
+info "Switching to new rootfs"
+fw_setenv mmcpart $PART
+fw_setenv upgrade_available 1
+
+info "Done!"
+rm_fit
+led_success || true
+
+if ! flag_set no-reboot; then
+    info "Unmounting new rootfs"
+    umount $MNT
+    sync; sync
+
+    info "Reboot system"
+    mqtt_status REBOOT
+    trap EXIT
+    flag_set "from-initramfs" && {
+        sync
+        reboot -f
+    } || reboot
+fi
+exit 0

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -2,6 +2,301 @@
 
 set -e
 
+if [ ! -e /proc/self ]; then
+    mount -t proc proc /proc
+fi
+
+if [ ! -e /dev/fd ]; then
+    ln -s /proc/self/fd /dev/fd
+fi
+
+if [ ! -e /etc/mtab ]; then
+    ln -s /proc/self/mounts /etc/mtab || true
+fi
+
+UPDATE_DIR="$(dirname "$FIT")"
+UPDATE_STATUS_FILE="$UPDATE_DIR/state/update.status"
+UPDATE_LOG_FILE="$UPDATE_DIR/state/update.log"
+
+if flag_set from-webupdate; then
+    info "Web UI-triggered update detected, forwarding logs and status to files"
+
+    mqtt_status() {
+        echo "$*" >> "$UPDATE_LOG_FILE"
+        echo "$*" > "$UPDATE_STATUS_FILE"
+    }
+
+    rm -rf "$UPDATE_LOG_FILE"
+fi
+
+ensure_tools() {
+    if [ -z "$TOOLPATH" ]; then
+        export TOOLPATH=$(mktemp -d)
+        mkdir -p "$TOOLPATH/proc" "$TOOLPATH/dev" "$TOOLPATH/etc" "$TOOLPATH/tmp"
+        mount -t proc proc "$TOOLPATH/proc"
+        ln -s /proc/self/mounts "$TOOLPATH/etc/mtab"
+        mount --bind /dev "$TOOLPATH/dev"
+
+        info "Temp toolpath: $TOOLPATH"
+
+        fit_blob_data rootfs | tar xz -C "$TOOLPATH" ./var/lib/wb-image-update/deps.tar.gz
+        tar xzf "$TOOLPATH/var/lib/wb-image-update/deps.tar.gz" -C "$TOOLPATH"
+    fi
+}
+
+run_tool() {
+    ensure_tools
+    chroot "$TOOLPATH" "$@"
+}
+
+disk_layout_is_ab() {
+    [ "$(blockdev --getsz /dev/mmcblk0p2)" -eq "$(blockdev --getsz /dev/mmcblk0p3)" ]
+}
+
+set_size() {
+    sed "s#^\\($1.*size=\\s\\+\\)[0-9]\\+\\(.*\\)#\\1 $2\\2#"
+}
+
+set_start() {
+    sed "s#^\\($1.*start=\\s\\+\\)[0-9]\\+\\(.*\\)#\\1 $2\\2#"
+}
+
+type mkfs_ext4 2>/dev/null | grep -q 'shell function' || {
+    mkfs_ext4() {
+        local part=$1
+        local label=$2
+
+        yes | mkfs.ext4 -L "$label" -E stride=2,stripe-width=1024 -b 4096 "$part"
+    }
+}
+ensure_enlarged_rootfs_parttable() {
+    if ! disk_layout_is_ab; then
+        info "Partition table seems to be changed already, continue"
+        return 0
+    fi
+
+    info "Unmounting everything"
+    umount /dev/mmcblk0p2 >/dev/null 2>&1 || true
+    umount /dev/mmcblk0p3 >/dev/null 2>&1 || true
+    umount /dev/mmcblk0p6 >/dev/null 2>&1 || true
+
+    info "Checking and repairing filesystem on /dev/mmcblk0p2"
+    run_tool e2fsck -f -p /dev/mmcblk0p2; E2FSCK_RC=$?
+
+    # e2fsck returns 1 and 2 if some errors were fixed, it's OK for us
+    if [ "$E2FSCK_RC" -gt 2 ]; then
+        info "Filesystem check failed, can't proceed with resizing"
+        return 1
+    fi
+
+    info "Backing up old MBR (and partition table)"
+    local mbr_backup
+    mbr_backup=$(mktemp)
+    dd if=/dev/mmcblk0 of="$mbr_backup" bs=512 count=1 || {
+        info "Failed to save MBR backup"
+        return 1
+    }
+
+    # Classic layout:
+    #
+    # label: dos
+    # label-id: 0x3f9de3f0
+    # device: /dev/mmcblk0
+    # unit: sectors
+    # sector-size: 512
+    #
+    # /dev/mmcblk0p1 : start=        2048, size=       32768, type=53
+    # /dev/mmcblk0p2 : start=       34816, size=     2097152, type=83
+    # /dev/mmcblk0p3 : start=     2131968, size=     2097152, type=83
+    # /dev/mmcblk0p4 : start=     4229120, size=   117913600, type=5
+    # /dev/mmcblk0p5 : start=     4231168, size=      524288, type=82
+    # /dev/mmcblk0p6 : start=     4757504, size=   117385216, type=83  # differs between models
+    #
+    # New layout with mmcblk0p3 size == 4 blocks:
+    #
+    # ...  # unchanged
+    # /dev/mmcblk0p2 : start=       34816, size=     4194300, type=83
+    # /dev/mmcblk0p3 : start=     4229116, size=           4, type=83
+    # /dev/mmcblk0p4 : start=     4229120, size=   117913600, type=5
+    # ...  # unchanged
+    #
+    # All this sfdisk magic is here to keep label-id and other partitions safe and sound
+
+    info "Creating a new parition table"
+    ROOTFS_START_BLOCKS=34816
+    ROOTFS_SIZE_BLOCKS=4194300
+
+    TEMP_DUMP="$(mktemp)"
+    info "New disk dump will be saved in $TEMP_DUMP"
+
+    sfdisk --dump /dev/mmcblk0 | \
+        set_size  /dev/mmcblk0p2 "$ROOTFS_SIZE_BLOCKS" | \
+        set_start /dev/mmcblk0p3 "$((ROOTFS_START_BLOCKS + ROOTFS_SIZE_BLOCKS))" | \
+        set_size  /dev/mmcblk0p3 4 | \
+        tee "$TEMP_DUMP" | \
+        sfdisk -f /dev/mmcblk0 >/dev/null || {
+
+        info "New parttable creation failed, restoring saved MBR backup"
+        dd if="$mbr_backup" of=/dev/mmcblk0 oflag=direct conv=notrunc || true
+        sync
+        blockdev --rereadpt /dev/mmcblk0 || true
+        return 1
+    }
+
+    sync
+    blockdev --rereadpt /dev/mmcblk0 || true
+
+    if [ "$(blockdev --getsz /dev/mmcblk0p2)" != "$ROOTFS_SIZE_BLOCKS" ]; then
+        info "New parttable is not applied, restoring saved MBR backup and exit"
+        dd if="$mbr_backup" of=/dev/mmcblk0 oflag=direct conv=notrunc || true
+        sync
+        blockdev --rereadpt /dev/mmcblk0 || true
+        die "Failed to apply a new partition table"
+    fi
+
+    info "Expanding filesystem on this partition"
+    local e2fs_undofile
+    e2fs_undofile=$(mktemp)
+    run_tool resize2fs -z "$e2fs_undofile" /dev/mmcblk0p2 || {
+        info "Filesystem expantion failed, restoring everything"
+        run_tool e2undo "$e2fs_undofile" /dev/mmcblk0p2 || true
+        dd if="$mbr_backup" of=/dev/mmcblk0 oflag=direct conv=notrunc || true
+        sync
+        blockdev --rereadpt /dev/mmcblk0 || true
+        return 1
+    }
+
+    info "Repartition is done!"
+}
+
+ensure_ab_rootfs_parttable() {
+    if disk_layout_is_ab; then
+        info "Partition table seems to be A/B, continue"
+        return 0
+    fi
+
+    info "Unmounting everything"
+    umount /dev/mmcblk0p2 >/dev/null 2>&1 || true
+    umount /dev/mmcblk0p3 >/dev/null 2>&1 || true
+    umount /dev/mmcblk0p6 >/dev/null 2>&1 || true
+
+    info "Checking and repairing filesystem on /dev/mmcblk0p2"
+    run_tool e2fsck -f -p /dev/mmcblk0p2; E2FSCK_RC=$?
+
+    # e2fsck returns 1 and 2 if some errors were fixed, it's OK for us
+    if [ "$E2FSCK_RC" -gt 2 ]; then
+        info "Filesystem check failed, can't proceed with resizing"
+        return 1
+    fi
+
+    info "Shrinking filesystem on /dev/mmcblk0p2"
+    local e2fs_undofile
+    e2fs_undofile=$(mktemp)
+    run_tool resize2fs -z "$e2fs_undofile" /dev/mmcblk0p2 262144 || {
+        info "Filesystem expantion failed, restoring everything"
+        run_tool e2undo "$e2fs_undofile" /dev/mmcblk0p2 || true
+        sync
+        return 1
+    }
+
+    info "Backing up old MBR (and partition table)"
+    local mbr_backup
+    mbr_backup=$(mktemp)
+    dd if=/dev/mmcblk0 of="$mbr_backup" bs=512 count=1 || {
+        info "Failed to save MBR backup"
+        return 1
+    }
+
+    # Classic layout:
+    #
+    # label: dos
+    # label-id: 0x3f9de3f0
+    # device: /dev/mmcblk0
+    # unit: sectors
+    # sector-size: 512
+    #
+    # /dev/mmcblk0p1 : start=        2048, size=       32768, type=53
+    # /dev/mmcblk0p2 : start=       34816, size=     2097152, type=83
+    # /dev/mmcblk0p3 : start=     2131968, size=     2097152, type=83
+    # /dev/mmcblk0p4 : start=     4229120, size=   117913600, type=5
+    # /dev/mmcblk0p5 : start=     4231168, size=      524288, type=82
+    # /dev/mmcblk0p6 : start=     4757504, size=   117385216, type=83  # differs between models
+    #
+    # All this sfdisk magic is here to keep label-id and other partitions safe and sound
+
+    info "Creating a new parition table"
+    ROOTFS_START_BLOCKS=34816
+    ROOTFS_SIZE_BLOCKS=2097152
+
+    TEMP_DUMP="$(mktemp)"
+    info "New disk dump will be saved in $TEMP_DUMP"
+
+    sfdisk --dump /dev/mmcblk0 | \
+        set_size  /dev/mmcblk0p2 "$ROOTFS_SIZE_BLOCKS" | \
+        set_start /dev/mmcblk0p3 "$((ROOTFS_START_BLOCKS + ROOTFS_SIZE_BLOCKS))" | \
+        set_size  /dev/mmcblk0p3 "$ROOTFS_SIZE_BLOCKS" | \
+        tee "$TEMP_DUMP" | \
+        sfdisk -f /dev/mmcblk0 >/dev/null || {
+
+        info "New parttable creation failed, restoring saved MBR backup"
+        dd if="$mbr_backup" of=/dev/mmcblk0 oflag=direct conv=notrunc || true
+        sync
+        blockdev --rereadpt /dev/mmcblk0 || true
+        return 1
+    }
+
+    sync
+    blockdev --rereadpt /dev/mmcblk0 || true
+
+    if [ "$(blockdev --getsz /dev/mmcblk0p2)" != "$ROOTFS_SIZE_BLOCKS" ]; then
+        info "New parttable is not applied, restoring saved MBR backup and exit"
+        dd if="$mbr_backup" of=/dev/mmcblk0 oflag=direct conv=notrunc || true
+        sync
+        blockdev --rereadpt /dev/mmcblk0 || true
+        die "Failed to apply a new partition table"
+    fi
+
+    info "Creating filesystem on second partition"
+    mkfs_ext4 /dev/mmcblk0p3 "rootfs" || {
+        info "Creating new filesystem on second partition failed!"
+        info "Restoring saved MBR backup and exit"
+        dd if="$mbr_backup" of=/dev/mmcblk0 oflag=direct conv=notrunc || true
+        sync
+        blockdev --rereadpt /dev/mmcblk0 || true
+        die "Failed to create filesystem on new rootfs, exiting"
+    }
+
+    info "Repartition is done!"
+}
+
+cleanup_rootfs() {
+    local ROOT_PART="$1"
+    local mountpoint
+    mountpoint="$(mktemp -d)"
+
+    mount -t ext4 "$ROOT_PART" "$mountpoint" >/dev/null 2>&1 || die "Unable to mount root filesystem"
+
+    info "Cleaning up $ROOT_PART"
+    rm -rf /tmp/empty && mkdir /tmp/empty
+    if which rsync >/dev/null; then
+        info "Cleaning up using rsync"
+        rsync -a --delete /tmp/empty/ "$mountpoint" || die "Failed to cleanup rootfs"
+    else
+        info "Can't find rsync, cleaning up using rm -rf (may be slower)"
+        rm -rf $mountpoint/..?* $mountpoint/.[!.]* $mountpoint/* || die "Failed to cleanup rootfs"
+    fi
+
+    umount "$mountpoint" || true
+}
+
+ensure_uboot_ready_for_webupd() {
+    local version
+    version=$(awk '{ print $2 }' /proc/device-tree/chosen/u-boot-version | sed 's/-g[0-9a-f]\+$//')
+    if dpkg --compare-versions "$version" lt "2021.10-wb1.5.0~~"; then
+        die "U-boot is outdated, update it manually or use factory reset with this FIT to install it"
+    fi
+}
+
 # FIXME: transitional definitions which are being moved to wb-run-update
 HIDDENFS_PART=/dev/mmcblk0p1
 HIDDENFS_OFFSET=$((8192*512))  # 8192 blocks of 512 bytes
@@ -15,14 +310,6 @@ type fit_prop_string 2>/dev/null | grep -q 'shell function' || {
     }
 }
 
-type mkfs_ext4 2>/dev/null | grep -q 'shell function' || {
-    mkfs_ext4() {
-        local part=$1
-        local label=$2
-
-        yes | mkfs.ext4 -L "$label" -E stride=2,stripe-width=1024 -b 4096 "$part"
-    }
-}
 
 
 check_compatible() {
@@ -60,55 +347,98 @@ case "$PART" in
 	2)
 		PART=3
 		PART_NOW=2
-		PARTLABEL=rootfs1
 		;;
 	3)
 		PART=2
 		PART_NOW=3
-		PARTLABEL=rootfs0
 		;;
 	*)
 		flag_set from-initramfs && {
 			info "Update is started from initramfs and unable to determine active rootfs partition, will overwrite rootfs0"
 			PART=2
 			PART_NOW=3
-			PARTLABEL=rootfs0
 		} || {
 			die "Unable to determine second rootfs partition (current is $PART)"
 		}
 		;;
 esac
+
+RESTORE_AB_FLAG=
+if flag_set from-initramfs && [ -e "$(dirname "$FIT")/restore_ab_rootfs" ];  then
+    RESTORE_AB_FLAG=true
+fi
+
+if flag_set "factoryreset" && ! flag_set "no-repartition"; then
+    if [ -n "$RESTORE_AB_FLAG" ]; then
+        cleanup_rootfs /dev/mmcblk0p2
+        info "restoring A/B scheme as requested"
+        if ensure_ab_rootfs_parttable; then
+            info "A/B scheme restored!"
+        else
+            die "Failed to restore A/B scheme"
+        fi
+    else
+        if ensure_enlarged_rootfs_parttable; then
+            info "rootfs enlarged!"
+        else
+            info "Repartition failed, continuing without it"
+        fi
+    fi
+fi
+
+# separate this from previous if to make it work
+# without factoryreset after repartition
+if ! disk_layout_is_ab; then
+
+    if ! flag_set from-initramfs; then
+        ensure_uboot_ready_for_webupd
+
+        info "Watch logs in the debug console, or in $UPDATE_LOG_FILE"
+        info "Single rootfs scheme detected, reboot system to perform update"
+        info "Waiting for Wiren Board to boot again..."
+
+        mv "$FIT" "$UPDATE_DIR/webupd.fit"
+
+        # write error note by default in the update status file,
+        # it will be overwritten if update script is started properly after reboot
+        echo "ERROR Nothing happened after reboot, maybe U-boot is outdated?" > "$UPDATE_STATUS_FILE"
+
+        fw_setenv wb_webupd 1
+
+        sync; sync
+        mqtt_status REBOOT
+        trap EXIT
+        reboot
+        exit 0
+    fi
+
+    info "Configuring environment for repartitioned eMMC"
+    PART=2
+    PART_NOW=nosuchpartition
+fi
+
 ROOT_PART=/dev/${ROOT_DEV}p${PART}
 info "Will install to $ROOT_PART"
 
 rm -rf "$MNT" && mkdir "$MNT" || die "Unable to create mountpoint $MNT"
 
-flag_set "from-initramfs" && {
-    actual_rootfs=/dev/${ROOT_DEV}p${PART_NOW}
-    info "Check if partition table is correct"
-    [[ -e $ROOT_PART ]] && [[ -e $actual_rootfs ]] || {
-        die "rootfs partition doesn't exist, looks like partitions table is broken. Give up."
-    }
-    info "Temporarily mount actual rootfs $actual_rootfs to check os-release"
-    mount -t ext4 $actual_rootfs $MNT 2>&1 >/dev/null && {
-        sync
-        ACTUAL_DEB_RELEASE="$(MNT="$MNT" bash -c 'source "$MNT/etc/os-release"; echo $VERSION_CODENAME')"
-        umount -f $actual_rootfs 2>&1 >/dev/null || true
-    } || true
-}
-
-# determine if new partition is unformatted
-mount -t ext4 $ROOT_PART $MNT 2>&1 >/dev/null || {
-    info "Unable to mount root partition, formatting $ROOT_PART"
-    mkfs_ext4 $ROOT_PART $PARTLABEL || die "mkfs.ext4 failed"
-}
-
-umount -f $ROOT_PART 2>&1 >/dev/null || true # just for sure
+actual_rootfs=/dev/${ROOT_DEV}p${PART_NOW}
+if flag_set from-initramfs ; then
+    if [[ -e "$actual_rootfs" ]]; then
+        info "Temporarily mount actual rootfs $actual_rootfs to check os-release"
+        mount -t ext4 $actual_rootfs $MNT 2>&1 >/dev/null && {
+            sync
+            ACTUAL_DEB_RELEASE="$(MNT="$MNT" bash -c 'source "$MNT/etc/os-release"; echo $VERSION_CODENAME')"
+            umount -f $actual_rootfs 2>&1 >/dev/null || true
+        } || true
+    fi
+else
+    ACTUAL_DEB_RELEASE="$(bash -c 'source "/etc/os-release"; echo $VERSION_CODENAME')"
+fi
 
 info "Mounting $ROOT_PART at $MNT"
 mount -t ext4 "$ROOT_PART" "$MNT" 2>&1 >/dev/null|| die "Unable to mount root filesystem"
 
-[[ -z "$ACTUAL_DEB_RELEASE" ]] && ACTUAL_DEB_RELEASE="$(bash -c 'source "/etc/os-release"; echo $VERSION_CODENAME')"
 upcoming_deb_release="$(fit_prop_string / release-target | sed 's/wb[[:digit:]]\+\///')"
 info "Debian: $ACTUAL_DEB_RELEASE -> $upcoming_deb_release"
 if [ "$ACTUAL_DEB_RELEASE" = "bullseye" ] && [ "$upcoming_deb_release" = "stretch" ]; then
@@ -140,15 +470,7 @@ EOF
     fi
 fi
 
-info "Cleaning up $ROOT_PART"
-rm -rf /tmp/empty && mkdir /tmp/empty
-if which rsync >/dev/null; then
-    info "Cleaning up using rsync"
-    rsync -a --delete /tmp/empty/ $MNT || die "Failed to cleanup rootfs"
-else
-    info "Can't find rsync, cleaning up using rm -rf (may be slower)"
-    rm -rf $MNT/..?* $MNT/.[!.]* $MNT/* || die "Failed to cleanup rootfs"
-fi
+cleanup_rootfs "$ROOT_PART"
 
 info "Extracting files to new rootfs"
 pushd "$MNT"

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -93,12 +93,14 @@ prepare_env() {
 
     UPDATE_DIR="$(dirname "$FIT")"
 
-	# FLAGS variable is defined in wb-run-update
-	# This is a hack to pass more flags from installation media for debugging
-	flags_file="$(dirname "$FIT")/install_update.flags"
-	if [ -e "$flags_file" ]; then
-		FLAGS+=" $(cat "$flags_file") "
-	fi
+    # FLAGS variable is defined in wb-run-update
+    # This is a hack to pass more flags from installation media for debugging
+    flags_file="$(dirname "$FIT")/install_update.flags"
+    if [ -e "$flags_file" ]; then
+        ADDITIONAL_FLAGS=$(cat "$flags_file")
+        info "Using flags from $flags_file: $ADDITIONAL_FLAGS"
+        FLAGS="$FLAGS $(ADDITIONAL_FLAGS) "
+    fi
 
     UPDATE_STATUS_FILE="$UPDATE_DIR/state/update.status"
     UPDATE_LOG_FILE="$UPDATE_DIR/state/update.log"
@@ -392,7 +394,7 @@ ensure_uboot_ready_for_webupd() {
 
 check_compatible() {
     local fit_compat
-	fit_compat=$(fit_prop_string / compatible)
+    fit_compat=$(fit_prop_string / compatible)
     [[ -z "$fit_compat" || "$fit_compat" == "unknown" ]] && return 0
     for compat in $(tr < /proc/device-tree/compatible  '\000' '\n'); do
         [[ "$fit_compat" == "$compat" ]] && return 0

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -2,36 +2,145 @@
 
 set -e
 
-if [ ! -e /proc/self ]; then
-    mount -t proc proc /proc
-fi
+ROOTDEV="${ROOTDEV:-/dev/mmcblk0}"
+TMPDIR="${TMPDIR:-/dev/shm}"
 
-if [ ! -e /dev/fd ]; then
-    ln -s /proc/self/fd /dev/fd
-fi
+ROOTFS1_PART=${ROOTDEV}p2
+ROOTFS2_PART=${ROOTDEV}p3
+DATA_PART=${ROOTDEV}p6
 
-if [ ! -e /etc/mtab ]; then
-    ln -s /proc/self/mounts /etc/mtab || true
-fi
+# appends a command to a trap
+#
+# - 1st arg:  code to add
+# - remaining args:  names of traps to modify
+#
+trap_add() {
+    trap_add_cmd=$1; shift || fatal "${FUNCNAME} usage error"
+    for trap_add_name in "$@"; do
+        trap -- "$( \
+            # helper fn to get existing trap command from output
+            # of trap -p
+            extract_trap_cmd() { printf '%s\n' "$3"; } \
+            # print existing trap command with newline
+            eval "extract_trap_cmd $(trap -p "${trap_add_name}")" \
+            # print the new trap command
+            printf '%s\n' "${trap_add_cmd}" \
+        )" "${trap_add_name}" \
+            || fatal "unable to add to trap ${trap_add_name}"
+    done
+}
 
-UPDATE_DIR="$(dirname "$FIT")"
-UPDATE_STATUS_FILE="$UPDATE_DIR/state/update.status"
-UPDATE_LOG_FILE="$UPDATE_DIR/state/update.log"
+return_code() {
+    return "$1"
+}
 
-if flag_set from-webupdate; then
-    info "Web UI-triggered update detected, forwarding logs and status to files"
+# This function replaces die() from wb-run-update script.
+# It reboots controller in case if script fails during Web-triggered update.
+fatal() {
+    local retcode=$?
+    local msg="$*"
 
-    mqtt_status() {
-        echo "$*" >> "$UPDATE_LOG_FILE"
-        echo "$*" > "$UPDATE_STATUS_FILE"
+    if flag_set from-initramfs; then
+        >&2 echo "!!! $msg"
+        if flag_set from-webupdate; then
+            mqtt_status "ERROR $msg"
+        fi
+        led_failure
+        bash -c 'source /lib/libupdate.sh; buzzer_init; buzzer_on; sleep 1; buzzer_off' || true
+
+        if ! flag_set no-reboot; then
+            reboot -f
+        fi
+
+        # we may be here if --no-reboot flag is set for debugging
+        exit "$retcode"
+    else
+        return_code "$retcode" || die "$msg"
+    fi
+}
+
+# takes an array of strings and prints them centered in a box
+print_centered_box() {
+    local width="${WIDTH:-80}"
+    local fill="${FILL:-#}"
+
+    printf "%*s\n" "$width" "" | tr ' ' "$fill"
+
+    for text in "$@"; do
+        local text_len=${#text}
+        local left_len=$(( (width - text_len) / 2 ))
+        local right_len=$(( width - text_len - left_len ))
+
+        printf "%*s%*s\n" "$(( left_len + text_len ))" "$text" "$right_len" ""
+    done
+
+    printf "%*s\n" "$width" "" | tr ' ' "$fill"
+}
+
+prepare_env() {
+    # fix mounts in bootlet environment
+    if [ ! -e /proc/self ]; then
+        mount -t proc proc /proc
+    fi
+
+    if [ ! -e /dev/fd ]; then
+        ln -s /proc/self/fd /dev/fd
+    fi
+
+    if [ ! -e /etc/mtab ]; then
+        ln -s /proc/self/mounts /etc/mtab || true
+    fi
+
+    UPDATE_DIR="$(dirname "$FIT")"
+
+	# FLAGS variable is defined in wb-run-update
+	# This is a hack to pass more flags from installation media for debugging
+	flags_file="$(dirname "$FIT")/install_update.flags"
+	if [ -e "$flags_file" ]; then
+		FLAGS+=" $(cat "$flags_file") "
+	fi
+
+    if flag_set from-webupdate; then
+        info "Web UI-triggered update detected, forwarding logs and status to files"
+        UPDATE_STATUS_FILE="$UPDATE_DIR/state/update.status"
+        UPDATE_LOG_FILE="$UPDATE_DIR/state/update.log"
+
+        mqtt_status() {
+            echo "$*" >> "$UPDATE_LOG_FILE"
+            echo "$*" > "$UPDATE_STATUS_FILE"
+        }
+
+        rm -rf "$UPDATE_LOG_FILE"
+    fi
+
+    type fit_prop_string 2>/dev/null | grep -q 'shell function' || {
+        fit_prop_string() {
+            fit_prop "$@" | tr -d '\0'
+        }
     }
 
-    rm -rf "$UPDATE_LOG_FILE"
-fi
+    type mkfs_ext4 2>/dev/null | grep -q 'shell function' || {
+        mkfs_ext4() {
+            local part=$1
+            local label=$2
+
+            yes | mkfs.ext4 -L "$label" -E stride=2,stripe-width=1024 -b 4096 "$part"
+        }
+    }
+
+
+    umount "$ROOTFS1_PART" >/dev/null 2>&1 || true
+    umount "$ROOTFS2_PART" >/dev/null 2>&1 || true
+
+    if ! flag_set from-webupdate; then
+        umount "$DATA_PART" >/dev/null 2>&1 || true
+    fi
+}
 
 ensure_tools() {
     if [ -z "$TOOLPATH" ]; then
-        export TOOLPATH=$(mktemp -d)
+        TOOLPATH=$(mktemp -d)
+        export TOOLPATH
         mkdir -p "$TOOLPATH/proc" "$TOOLPATH/dev" "$TOOLPATH/etc" "$TOOLPATH/tmp"
         mount -t proc proc "$TOOLPATH/proc"
         ln -s /proc/self/mounts "$TOOLPATH/etc/mtab"
@@ -50,38 +159,25 @@ run_tool() {
 }
 
 disk_layout_is_ab() {
-    [ "$(blockdev --getsz /dev/mmcblk0p2)" -eq "$(blockdev --getsz /dev/mmcblk0p3)" ]
+    [ "$(blockdev --getsz "$ROOTFS1_PART")" -eq "$(blockdev --getsz "$ROOTFS2_PART")" ]
 }
 
-set_size() {
+sfdisk_set_size() {
     sed "s#^\\($1.*size=\\s\\+\\)[0-9]\\+\\(.*\\)#\\1 $2\\2#"
 }
 
-set_start() {
+sfdisk_set_start() {
     sed "s#^\\($1.*start=\\s\\+\\)[0-9]\\+\\(.*\\)#\\1 $2\\2#"
 }
 
-type mkfs_ext4 2>/dev/null | grep -q 'shell function' || {
-    mkfs_ext4() {
-        local part=$1
-        local label=$2
-
-        yes | mkfs.ext4 -L "$label" -E stride=2,stripe-width=1024 -b 4096 "$part"
-    }
-}
 ensure_enlarged_rootfs_parttable() {
     if ! disk_layout_is_ab; then
         info "Partition table seems to be changed already, continue"
         return 0
     fi
 
-    info "Unmounting everything"
-    umount /dev/mmcblk0p2 >/dev/null 2>&1 || true
-    umount /dev/mmcblk0p3 >/dev/null 2>&1 || true
-    umount /dev/mmcblk0p6 >/dev/null 2>&1 || true
-
-    info "Checking and repairing filesystem on /dev/mmcblk0p2"
-    run_tool e2fsck -f -p /dev/mmcblk0p2; E2FSCK_RC=$?
+    info "Checking and repairing filesystem on $ROOTFS1_PART"
+    run_tool e2fsck -f -p "$ROOTFS1_PART"; E2FSCK_RC=$?
 
     # e2fsck returns 1 and 2 if some errors were fixed, it's OK for us
     if [ "$E2FSCK_RC" -gt 2 ]; then
@@ -129,40 +225,40 @@ ensure_enlarged_rootfs_parttable() {
     TEMP_DUMP="$(mktemp)"
     info "New disk dump will be saved in $TEMP_DUMP"
 
-    sfdisk --dump /dev/mmcblk0 | \
-        set_size  /dev/mmcblk0p2 "$ROOTFS_SIZE_BLOCKS" | \
-        set_start /dev/mmcblk0p3 "$((ROOTFS_START_BLOCKS + ROOTFS_SIZE_BLOCKS))" | \
-        set_size  /dev/mmcblk0p3 4 | \
+    sfdisk --dump "$ROOTDEV" | \
+        sfdisk_set_size  "$ROOTFS1_PART" "$ROOTFS_SIZE_BLOCKS" | \
+        sfdisk_set_start "$ROOTFS2_PART" "$((ROOTFS_START_BLOCKS + ROOTFS_SIZE_BLOCKS))" | \
+        sfdisk_set_size  "$ROOTFS2_PART" 4 | \
         tee "$TEMP_DUMP" | \
-        sfdisk -f /dev/mmcblk0 >/dev/null || {
+        sfdisk -f "$ROOTDEV" >/dev/null || {
 
         info "New parttable creation failed, restoring saved MBR backup"
-        dd if="$mbr_backup" of=/dev/mmcblk0 oflag=direct conv=notrunc || true
+        dd if="$mbr_backup" of="$ROOTDEV" oflag=direct conv=notrunc || true
         sync
-        blockdev --rereadpt /dev/mmcblk0 || true
+        blockdev --rereadpt "$ROOTDEV" || true
         return 1
     }
 
     sync
-    blockdev --rereadpt /dev/mmcblk0 || true
+    blockdev --rereadpt "$ROOTDEV" || true
 
-    if [ "$(blockdev --getsz /dev/mmcblk0p2)" != "$ROOTFS_SIZE_BLOCKS" ]; then
+    if [ "$(blockdev --getsz "$ROOTFS1_PART")" != "$ROOTFS_SIZE_BLOCKS" ]; then
         info "New parttable is not applied, restoring saved MBR backup and exit"
-        dd if="$mbr_backup" of=/dev/mmcblk0 oflag=direct conv=notrunc || true
+        dd if="$mbr_backup" of="$ROOTDEV" oflag=direct conv=notrunc || true
         sync
-        blockdev --rereadpt /dev/mmcblk0 || true
-        die "Failed to apply a new partition table"
+        blockdev --rereadpt "$ROOTDEV" || true
+        fatal "Failed to apply a new partition table"
     fi
 
     info "Expanding filesystem on this partition"
     local e2fs_undofile
     e2fs_undofile=$(mktemp)
-    run_tool resize2fs -z "$e2fs_undofile" /dev/mmcblk0p2 || {
+    run_tool resize2fs -z "$e2fs_undofile" "$ROOTFS1_PART" || {
         info "Filesystem expantion failed, restoring everything"
-        run_tool e2undo "$e2fs_undofile" /dev/mmcblk0p2 || true
-        dd if="$mbr_backup" of=/dev/mmcblk0 oflag=direct conv=notrunc || true
+        run_tool e2undo "$e2fs_undofile" "$ROOTFS1_PART" || true
+        dd if="$mbr_backup" of="$ROOTDEV" oflag=direct conv=notrunc || true
         sync
-        blockdev --rereadpt /dev/mmcblk0 || true
+        blockdev --rereadpt "$ROOTDEV" || true
         return 1
     }
 
@@ -175,13 +271,8 @@ ensure_ab_rootfs_parttable() {
         return 0
     fi
 
-    info "Unmounting everything"
-    umount /dev/mmcblk0p2 >/dev/null 2>&1 || true
-    umount /dev/mmcblk0p3 >/dev/null 2>&1 || true
-    umount /dev/mmcblk0p6 >/dev/null 2>&1 || true
-
-    info "Checking and repairing filesystem on /dev/mmcblk0p2"
-    run_tool e2fsck -f -p /dev/mmcblk0p2; E2FSCK_RC=$?
+    info "Checking and repairing filesystem on $ROOTFS1_PART"
+    run_tool e2fsck -f -p "$ROOTFS1_PART"; E2FSCK_RC=$?
 
     # e2fsck returns 1 and 2 if some errors were fixed, it's OK for us
     if [ "$E2FSCK_RC" -gt 2 ]; then
@@ -189,12 +280,12 @@ ensure_ab_rootfs_parttable() {
         return 1
     fi
 
-    info "Shrinking filesystem on /dev/mmcblk0p2"
+    info "Shrinking filesystem on $ROOTFS1_PART"
     local e2fs_undofile
     e2fs_undofile=$(mktemp)
-    run_tool resize2fs -z "$e2fs_undofile" /dev/mmcblk0p2 262144 || {
+    run_tool resize2fs -z "$e2fs_undofile" "$ROOTFS1_PART" 262144 || {
         info "Filesystem expantion failed, restoring everything"
-        run_tool e2undo "$e2fs_undofile" /dev/mmcblk0p2 || true
+        run_tool e2undo "$e2fs_undofile" "$ROOTFS1_PART" || true
         sync
         return 1
     }
@@ -202,7 +293,7 @@ ensure_ab_rootfs_parttable() {
     info "Backing up old MBR (and partition table)"
     local mbr_backup
     mbr_backup=$(mktemp)
-    dd if=/dev/mmcblk0 of="$mbr_backup" bs=512 count=1 || {
+    dd if="$ROOTDEV" of="$mbr_backup" bs=512 count=1 || {
         info "Failed to save MBR backup"
         return 1
     }
@@ -231,39 +322,39 @@ ensure_ab_rootfs_parttable() {
     TEMP_DUMP="$(mktemp)"
     info "New disk dump will be saved in $TEMP_DUMP"
 
-    sfdisk --dump /dev/mmcblk0 | \
-        set_size  /dev/mmcblk0p2 "$ROOTFS_SIZE_BLOCKS" | \
-        set_start /dev/mmcblk0p3 "$((ROOTFS_START_BLOCKS + ROOTFS_SIZE_BLOCKS))" | \
-        set_size  /dev/mmcblk0p3 "$ROOTFS_SIZE_BLOCKS" | \
+    sfdisk --dump "$ROOTDEV" | \
+        sfdisk_set_size  "$ROOTFS1_PART" "$ROOTFS_SIZE_BLOCKS" | \
+        sfdisk_set_start "$ROOTFS2_PART" "$((ROOTFS_START_BLOCKS + ROOTFS_SIZE_BLOCKS))" | \
+        sfdisk_set_size  "$ROOTFS2_PART" "$ROOTFS_SIZE_BLOCKS" | \
         tee "$TEMP_DUMP" | \
-        sfdisk -f /dev/mmcblk0 >/dev/null || {
+        sfdisk -f "$ROOTDEV" >/dev/null || {
 
         info "New parttable creation failed, restoring saved MBR backup"
-        dd if="$mbr_backup" of=/dev/mmcblk0 oflag=direct conv=notrunc || true
+        dd if="$mbr_backup" of="$ROOTDEV" oflag=direct conv=notrunc || true
         sync
-        blockdev --rereadpt /dev/mmcblk0 || true
+        blockdev --rereadpt "$ROOTDEV" || true
         return 1
     }
 
     sync
-    blockdev --rereadpt /dev/mmcblk0 || true
+    blockdev --rereadpt "$ROOTDEV" || true
 
-    if [ "$(blockdev --getsz /dev/mmcblk0p2)" != "$ROOTFS_SIZE_BLOCKS" ]; then
+    if [ "$(blockdev --getsz "$ROOTFS1_PART")" != "$ROOTFS_SIZE_BLOCKS" ]; then
         info "New parttable is not applied, restoring saved MBR backup and exit"
-        dd if="$mbr_backup" of=/dev/mmcblk0 oflag=direct conv=notrunc || true
+        dd if="$mbr_backup" of="$ROOTDEV" oflag=direct conv=notrunc || true
         sync
-        blockdev --rereadpt /dev/mmcblk0 || true
-        die "Failed to apply a new partition table"
+        blockdev --rereadpt "$ROOTDEV" || true
+        fatal "Failed to apply a new partition table"
     fi
 
     info "Creating filesystem on second partition"
-    mkfs_ext4 /dev/mmcblk0p3 "rootfs" || {
+    mkfs_ext4 "$ROOTFS2_PART" "rootfs" || {
         info "Creating new filesystem on second partition failed!"
         info "Restoring saved MBR backup and exit"
-        dd if="$mbr_backup" of=/dev/mmcblk0 oflag=direct conv=notrunc || true
+        dd if="$mbr_backup" of="$ROOTDEV" oflag=direct conv=notrunc || true
         sync
-        blockdev --rereadpt /dev/mmcblk0 || true
-        die "Failed to create filesystem on new rootfs, exiting"
+        blockdev --rereadpt "$ROOTDEV" || true
+        fatal "Failed to create filesystem on new rootfs, exiting"
     }
 
     info "Repartition is done!"
@@ -274,16 +365,16 @@ cleanup_rootfs() {
     local mountpoint
     mountpoint="$(mktemp -d)"
 
-    mount -t ext4 "$ROOT_PART" "$mountpoint" >/dev/null 2>&1 || die "Unable to mount root filesystem"
+    mount -t ext4 "$ROOT_PART" "$mountpoint" >/dev/null 2>&1 || fatal "Unable to mount root filesystem"
 
     info "Cleaning up $ROOT_PART"
     rm -rf /tmp/empty && mkdir /tmp/empty
     if which rsync >/dev/null; then
         info "Cleaning up using rsync"
-        rsync -a --delete /tmp/empty/ "$mountpoint" || die "Failed to cleanup rootfs"
+        rsync -a --delete /tmp/empty/ "$mountpoint" || fatal "Failed to cleanup rootfs"
     else
         info "Can't find rsync, cleaning up using rm -rf (may be slower)"
-        rm -rf $mountpoint/..?* $mountpoint/.[!.]* $mountpoint/* || die "Failed to cleanup rootfs"
+        rm -rf "$mountpoint"/..?* "$mountpoint"/.[!.]* "${mountpoint:?}"/* || fatal "Failed to cleanup rootfs"
     fi
 
     umount "$mountpoint" || true
@@ -293,89 +384,54 @@ ensure_uboot_ready_for_webupd() {
     local version
     version=$(awk '{ print $2 }' /proc/device-tree/chosen/u-boot-version | sed 's/-g[0-9a-f]\+$//')
     if dpkg --compare-versions "$version" lt "2021.10-wb1.5.0~~"; then
-        die "U-boot is outdated, update it manually or use factory reset with this FIT to install it"
+        info "Flashed U-boot version is too old, updating it before reboot"
+        u-boot-install-wb -f || fatal "Failed to update U-boot"
     fi
 }
 
-# FIXME: transitional definitions which are being moved to wb-run-update
-HIDDENFS_PART=/dev/mmcblk0p1
-HIDDENFS_OFFSET=$((8192*512))  # 8192 blocks of 512 bytes
-DEVCERT_NAME="device.crt.pem"
-INTERM_NAME="intermediate.crt.pem"
-ROOTFS_CERT_PATH="/etc/ssl/certs/device_bundle.crt.pem"
-
-type fit_prop_string 2>/dev/null | grep -q 'shell function' || {
-    fit_prop_string() {
-        fit_prop "$@" | tr -d '\0'
-    }
-}
-
-
-
 check_compatible() {
-	local fit_compat=`fit_prop_string / compatible`
-	[[ -z "$fit_compat" || "$fit_compat" == "unknown" ]] && return 0
-	for compat in `tr < /proc/device-tree/compatible  '\000' '\n'`; do
-		[[ "$fit_compat" == "$compat" ]] && return 0
-	done
-	return 1
+    local fit_compat
+	fit_compat=$(fit_prop_string / compatible)
+    [[ -z "$fit_compat" || "$fit_compat" == "unknown" ]] && return 0
+    for compat in $(tr < /proc/device-tree/compatible  '\000' '\n'); do
+        [[ "$fit_compat" == "$compat" ]] && return 0
+    done
+    return 1
 }
 
-if flag_set "force-compatible"; then
-	info "WARNING: Don't check compatibility. I hope you know what you're doing..."
-else
-	check_compatible || die "This update is incompatible with this device"
-fi
+select_new_partition() {
+    info "Getting mmcpart from U-Boot environment"
+    PART=$(fw_printenv mmcpart | sed 's/.*=//') || PART=""
 
-fit_blob_verify_hash rootfs
+    case "$PART" in
+        2)
+            PART=3
+            PREVIOUS_PART=2
+            ;;
+        3)
+            PART=2
+            PREVIOUS_PART=3
+            ;;
+        *)
+            if flag_set from-initramfs; then
+                info "Update is started from initramfs and unable to determine active rootfs partition, will overwrite rootfs0"
+                PART=2
+                PREVIOUS_PART=3
+            else
+                fatal "Unable to determine second rootfs partition (current is '$PART')"
+            fi
+            ;;
+    esac
+}
 
-info "Installing firmware update"
-
-MNT="$TMPDIR/rootfs"
-ACTUAL_DEB_RELEASE=""
-
-ROOT_DEV='mmcblk0'
-if [[ -e "/dev/root" ]]; then
-	PART=`readlink /dev/root`
-	PART=${PART##*${ROOT_DEV}p}
-else
-	info "Getting mmcpart from U-Boot environment"
-	PART=$(fw_printenv mmcpart | sed 's/.*=//') || PART=""
-fi
-
-case "$PART" in
-	2)
-		PART=3
-		PART_NOW=2
-		;;
-	3)
-		PART=2
-		PART_NOW=3
-		;;
-	*)
-		flag_set from-initramfs && {
-			info "Update is started from initramfs and unable to determine active rootfs partition, will overwrite rootfs0"
-			PART=2
-			PART_NOW=3
-		} || {
-			die "Unable to determine second rootfs partition (current is $PART)"
-		}
-		;;
-esac
-
-RESTORE_AB_FLAG=
-if flag_set from-initramfs && [ -e "$(dirname "$FIT")/restore_ab_rootfs" ];  then
-    RESTORE_AB_FLAG=true
-fi
-
-if flag_set "factoryreset" && ! flag_set "no-repartition"; then
-    if [ -n "$RESTORE_AB_FLAG" ]; then
-        cleanup_rootfs /dev/mmcblk0p2
+maybe_repartition() {
+    if flag_set restore-ab-rootfs ; then
+        cleanup_rootfs "$ROOTFS1_PART"
         info "restoring A/B scheme as requested"
         if ensure_ab_rootfs_parttable; then
             info "A/B scheme restored!"
         else
-            die "Failed to restore A/B scheme"
+            fatal "Failed to restore A/B scheme"
         fi
     else
         if ensure_enlarged_rootfs_parttable; then
@@ -384,165 +440,240 @@ if flag_set "factoryreset" && ! flag_set "no-repartition"; then
             info "Repartition failed, continuing without it"
         fi
     fi
-fi
+}
 
-# separate this from previous if to make it work
-# without factoryreset after repartition
-if ! disk_layout_is_ab; then
+get_update_debian_version() {
+    fit_prop_string / release-target | sed 's/wb[[:digit:]]\+\///'
+}
 
-    if ! flag_set from-initramfs; then
-        ensure_uboot_ready_for_webupd
+get_installed_debian_version() {
+    actual_rootfs=${ROOTDEV}p${PREVIOUS_PART}
+    local MNT
+    MNT=$(mktemp -d)
 
-        info "Watch logs in the debug console, or in $UPDATE_LOG_FILE"
-        info "Single rootfs scheme detected, reboot system to perform update"
-        info "Waiting for Wiren Board to boot again..."
-
-        mv "$FIT" "$UPDATE_DIR/webupd.fit"
-
-        # write error note by default in the update status file,
-        # it will be overwritten if update script is started properly after reboot
-        echo "ERROR Nothing happened after reboot, maybe U-boot is outdated?" > "$UPDATE_STATUS_FILE"
-
-        fw_setenv wb_webupd 1
-
-        sync; sync
-        mqtt_status REBOOT
-        trap EXIT
-        reboot
-        exit 0
+    if flag_set from-initramfs ; then
+        if [[ -e "$actual_rootfs" ]]; then
+            info "Temporarily mount actual rootfs $actual_rootfs to check previous OS release"
+            if mount -t ext4 "$actual_rootfs" "$MNT" >/dev/null 2>&1 ; then
+                sync
+                source "$MNT/etc/os-release"
+                echo "$VERSION_CODENAME"
+                umount -f "$actual_rootfs" >/dev/null 2>&1 || true
+            else
+                info "Failed to mount rootfs from $actual_rootfs, skipping release check"
+                echo "unknown"
+            fi
+        fi
+    else
+        source "/etc/os-release"
+        echo "$VERSION_CODENAME"
     fi
+}
 
-    info "Configuring environment for repartitioned eMMC"
-    PART=2
-    PART_NOW=nosuchpartition
-fi
+ensure_no_downgrade() {
+    actual=$(get_installed_debian_version)
+    upcoming=$(get_update_debian_version)
 
-ROOT_PART=/dev/${ROOT_DEV}p${PART}
-info "Will install to $ROOT_PART"
+    info "Debian: $actual -> $upcoming"
+    if [ "$actual" = "bullseye" ] && [ "$upcoming" = "stretch" ]; then
+        if ! flag_set factoryreset; then
+            message=(
+                ""
+                "ROLLBACK FROM $actual TO $upcoming REQUESTED"
+                ""
+                "Due to major Debian release changes,"
+                "this operation is allowed only via FACTORYRESET."
+                ""
+                "Rename .fit file to \"wbX_update_FACTORYRESET.fit\" ->"
+                "put renamed file to usb-drive ->"
+                "ensure, there is only one .fit file on usb-drive ->"
+                "insert usb-drive to controller and reboot ->"
+                "follow further factoryreset instructions."
+                ""
+            )
 
-rm -rf "$MNT" && mkdir "$MNT" || die "Unable to create mountpoint $MNT"
-
-actual_rootfs=/dev/${ROOT_DEV}p${PART_NOW}
-if flag_set from-initramfs ; then
-    if [[ -e "$actual_rootfs" ]]; then
-        info "Temporarily mount actual rootfs $actual_rootfs to check os-release"
-        mount -t ext4 $actual_rootfs $MNT 2>&1 >/dev/null && {
-            sync
-            ACTUAL_DEB_RELEASE="$(MNT="$MNT" bash -c 'source "$MNT/etc/os-release"; echo $VERSION_CODENAME')"
-            umount -f $actual_rootfs 2>&1 >/dev/null || true
-        } || true
-    fi
-else
-    ACTUAL_DEB_RELEASE="$(bash -c 'source "/etc/os-release"; echo $VERSION_CODENAME')"
-fi
-
-info "Mounting $ROOT_PART at $MNT"
-mount -t ext4 "$ROOT_PART" "$MNT" 2>&1 >/dev/null|| die "Unable to mount root filesystem"
-
-upcoming_deb_release="$(fit_prop_string / release-target | sed 's/wb[[:digit:]]\+\///')"
-info "Debian: $ACTUAL_DEB_RELEASE -> $upcoming_deb_release"
-if [ "$ACTUAL_DEB_RELEASE" = "bullseye" ] && [ "$upcoming_deb_release" = "stretch" ]; then
-    if ! flag_set factoryreset; then
-        >&2 cat <<EOF
-##############################################################################
-
-    ROLLBACK FROM $ACTUAL_DEB_RELEASE TO $upcoming_deb_release REQUESTED
-
-                    Due to major Debian release changes,
-                this operation is allowed only via FACTORYRESET.
-
-    Rename .fit file to "wbX_update_FACTORYRESET.fit" ->
-    put renamed file to usb-drive ->
-    ensure, there is only one .fit file on usb-drive ->
-    insert usb-drive to controller and reboot ->
-    follow further factoryreset instructions.
-
-##############################################################################
-EOF
-        if flag_set from-initramfs; then
-            led_failure
-            bash -c 'source /lib/libupdate.sh; buzzer_init; buzzer_on; sleep 1; buzzer_off'
-            info "Rebooting..."
-            reboot -f
-        else
-            die "Aborting..."
+            print_centered_box "${message[@]}"
+            fatal "Rollback from $actual to $upcoming is not allowed"
         fi
     fi
-fi
+}
 
-cleanup_rootfs "$ROOT_PART"
+mount_rootfs() {
+    local ROOT_PART=$1
+    local MNT=$2
+    info "Mounting $ROOT_PART at $MNT"
+    mount -t ext4 "$ROOT_PART" "$MNT" >/dev/null 2>&1 || fatal "Unable to mount root filesystem"
 
-info "Extracting files to new rootfs"
-pushd "$MNT"
-blob_size=`fit_blob_size rootfs`
-(
-	echo 0
-	fit_blob_data rootfs | pv -n -s "$blob_size" | tar xzp || die "Failed to extract rootfs"
-) 2>&1 | mqtt_progress "$x"
-popd
+    trap_add "info 'Unmounting rootfs'; umount -f $MNT >/dev/null 2>&1 || true ; sync; sync" EXIT
+}
 
-if ! flag_set no-certificates; then
+extract_rootfs() {
+    local MNT=$1
+
+    info "Extracting files to new rootfs"
+    pushd "$MNT"
+    blob_size=$(fit_blob_size rootfs)
+    (
+        echo 0
+        fit_blob_data rootfs | pv -n -s "$blob_size" | tar xzp || fatal "Failed to extract rootfs"
+    ) 2>&1 | mqtt_progress "$x"
+    popd
+}
+
+recover_certificates() {
+    HIDDENFS_PART=${ROOTDEV}p1
+    HIDDENFS_OFFSET=$((8192*512))  # 8192 blocks of 512 bytes
+    DEVCERT_NAME="device.crt.pem"
+    INTERM_NAME="intermediate.crt.pem"
+    ROOTFS_CERT_PATH="/etc/ssl/certs/device_bundle.crt.pem"
+
+    local ROOTFS_MNT=$1
+
+    local HIDDENFS_MNT
+    HIDDENFS_MNT=$(mktemp -d)
+
     info "Recovering device certificates"
-    HIDDENFS_MNT=$TMPDIR/hiddenfs
-    mkdir -p $HIDDENFS_MNT
-
     # make loop device
-    LO_DEVICE=`losetup -f`
-    losetup -r -o $HIDDENFS_OFFSET $LO_DEVICE $HIDDENFS_PART ||
-        die "Failed to add loopback device"
+    LO_DEVICE=$(losetup -f)
+    losetup -r -o "$HIDDENFS_OFFSET" "$LO_DEVICE" "$HIDDENFS_PART" ||
+        fatal "Failed to add loopback device"
 
-    if mount $LO_DEVICE $HIDDENFS_MNT 2>&1 >/dev/null; then
-        cat $HIDDENFS_MNT/$INTERM_NAME $HIDDENFS_MNT/$DEVCERT_NAME > $MNT/$ROOTFS_CERT_PATH ||
-            info "WARNING: Failed to copy device certificate bundle into new rootfs. Please report it to info@contactless.ru"
-        umount $HIDDENFS_MNT
+    if mount "$LO_DEVICE" "$HIDDENFS_MNT" >/dev/null 2>&1; then
+        cat "$HIDDENFS_MNT/$INTERM_NAME" "$HIDDENFS_MNT/$DEVCERT_NAME" > "$ROOTFS_MNT/$ROOTFS_CERT_PATH" ||
+            info "WARNING: Failed to copy device certificate bundle into new rootfs. Please report it to info@wirenboard.com"
+        umount "$HIDDENFS_MNT"
         sync
     else
         info "WARNING: Failed to find certificates of device. Please report it to info@contactless.ru"
     fi
-fi
+}
 
-if ! flag_set no-postinst; then
+run_postinst() {
+    local ROOTFS_MNT=$1
+
     info "Mount /dev, /proc and /sys to rootfs"
-    mount -o bind /dev "$MNT/dev"
-    mount -o bind /proc "$MNT/proc"
-    mount -o bind /sys "$MNT/sys"
+    mount -o bind /dev "$ROOTFS_MNT/dev"
+    mount -o bind /proc "$ROOTFS_MNT/proc"
+    mount -o bind /sys "$ROOTFS_MNT/sys"
 
-    POSTINST_DIR="$MNT/usr/lib/wb-image-update/postinst/"
+    POSTINST_DIR="$ROOTFS_MNT/usr/lib/wb-image-update/postinst/"
     if [[ -d "$POSTINST_DIR" ]]; then
         info "Running post-install scripts"
 
         POSTINST_FILES="$(find "$POSTINST_DIR" -maxdepth 1 -type f | sort)"
         for file in $POSTINST_FILES; do
             info "> Processing $file"
-            FIT="$FIT" "$file" "$MNT" "$FLAGS" || true
+            FIT="$FIT" "$file" "$ROOTFS_MNT" "$FLAGS" || true
         done
     fi
 
     info "Unmounting /dev, /proc and /sys from rootfs"
-    umount "$MNT/dev"
-    umount "$MNT/proc"
-    umount "$MNT/sys"
+    umount "$ROOTFS_MNT/dev"
+    umount "$ROOTFS_MNT/proc"
+    umount "$ROOTFS_MNT/sys"
+}
+
+maybe_reboot() {
+    if ! flag_set no-reboot; then
+        info "Reboot system"
+        mqtt_status REBOOT
+        sync; sync
+
+        if flag_set from-initramfs; then
+            reboot -f
+        else
+            reboot
+        fi
+    fi
+    exit 0
+}
+
+update_after_reboot() {
+    ensure_uboot_ready_for_webupd
+
+    info "Watch logs in the debug console, or in $UPDATE_LOG_FILE"
+    info "Single rootfs scheme detected, reboot system to perform update"
+    info "Waiting for Wiren Board to boot again..."
+
+    mv "$FIT" "$UPDATE_DIR/webupd.fit"
+
+    # write error note by default in the update status file,
+    # it will be overwritten if update script is started properly after reboot
+    echo "ERROR Nothing happened after reboot, maybe U-boot is outdated?" > "$UPDATE_DIR/state/update.status"
+
+    fw_setenv wb_webupd 1
+
+    maybe_reboot
+}
+
+#---------------------------------------- main ----------------------------------------
+
+prepare_env
+
+# --fail flag allows to simulate failed update for testing purposes
+if flag_set fail; then
+    fatal "Update failed by request"
+fi
+
+if flag_set force-compatible; then
+    info "WARNING: Don't check compatibility. I hope you know what you're doing..."
+else
+    check_compatible || fatal "This update is incompatible with this device"
+fi
+
+if ! fit_blob_verify_hash rootfs; then
+    fatal "rootfs blob hash verification failed"
+else
+    info "rootfs is valid, installing firmware update"
+fi
+
+# separate this from previous if to make it work
+# without factoryreset after repartition
+if ! flag_set from-initramfs; then
+    if ! disk_layout_is_ab; then
+        update_after_reboot
+    fi
+fi
+
+if flag_set "factoryreset" && ! flag_set "no-repartition"; then
+    maybe_repartition
+fi
+
+if disk_layout_is_ab; then
+    select_new_partition
+else
+    info "Configuring environment for repartitioned eMMC"
+    PART=2
+    PREVIOUS_PART=nosuchpartition
+fi
+
+ROOT_PART=${ROOTDEV}p${PART}
+info "Will install to $ROOT_PART"
+
+if ! flag_set factoryreset; then
+    ensure_no_downgrade
+fi
+
+cleanup_rootfs "$ROOT_PART"
+
+MNT="$(mktemp -d)"
+mount_rootfs "$ROOT_PART" "$MNT"
+extract_rootfs "$MNT"
+
+if ! flag_set no-certificates; then
+    recover_certificates "$MNT"
+fi
+
+if ! flag_set no-postinst; then
+    run_postinst "$MNT"
 fi
 
 info "Switching to new rootfs"
-fw_setenv mmcpart $PART
+fw_setenv mmcpart "$PART"
 fw_setenv upgrade_available 1
 
 info "Done!"
 rm_fit
 led_success || true
 
-if ! flag_set no-reboot; then
-    info "Unmounting new rootfs"
-    umount $MNT
-    sync; sync
-
-    info "Reboot system"
-    mqtt_status REBOOT
-    trap EXIT
-    flag_set "from-initramfs" && {
-        sync
-        reboot -f
-    } || reboot
-fi
-exit 0
+maybe_reboot


### PR DESCRIPTION
Этот PR добавляет поддержку расширения rootfs при обновлении WB7 с factoryreset.

Скрипт install_update.sh переехал из репозитория wirenboard сюда, так собранные образы могут иметь разные версии установочного скрипта в зависимости от rootfs. Скрипт пережил рефакторинг, стал чуть более читаемым и получил некоторые отладочные фичи (например, если рядом с FIT положить файл `install_update.flags`, то при установке содержимое этого файла будет парситься как флаги, с которыми запущен wb-run-update).

Также задействовано ранее не использованное поле `firmware-compatible` в FIT, чтобы различать образы с поддержкой расширения rootfs и без неё.

Я написал тест-кейсы в kiwi и проверил перед созданием PR, что обновление работает как надо, как и откат к старой схеме.

У этого обновления есть ломающее изменение, с которым мы сейчас ничего не сможем сделать: factory reset для контроллеров со старыми образами будет сломан после перехода на схему с одним rootfs. Возможно, при factory reset с новыми образами stable с флешки можно будет замещать заводской образ с контроллера, но это будет обсуждаться позже.

Аналогичный PR в stable хочу сделать после ревью этого, отличия там будут минимальными (при factoryreset будет попытка откатиться до старой схемы rootfs).

Перед мержем:

- [ ] должен быть влит аналогичный PR в stable, который откатывает таблицу разделов до старой A/B версии при factory reset со stable
- [x] должна быть выложена новая версия бутлета с обновлённым initramfs на S3