### PR TITLE
wb-image-update: get FIT bootlet during rootfs creation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.9.1) stable; urgency=medium
+
+  * wb-image-update: get FIT bootlet during rootfs creation
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Fri, 21 Apr 2023 01:11:16 +0600
+
 wb-utils (4.9.0) stable; urgency=medium
 
   * move install_update.sh script for FIT images to this package

--- a/utils/lib/wb-image-update/fit/build.sh
+++ b/utils/lib/wb-image-update/fit/build.sh
@@ -88,3 +88,10 @@ cp /usr/lib/wb-image-update/fit/install_update.sh /var/lib/wb-image-update/insta
 cd "$BUILDDIR" && tar cvzf /var/lib/wb-image-update/deps.tar.gz .
 
 echo "+single-rootfs " > /var/lib/wb-image-update/firmware-compatible
+
+# FIXME: install bootlet image as deb package
+BOOTLET_ZIMAGE=/var/lib/wb-image-update/zImage
+if [[ ! -e "$BOOTLET_ZIMAGE" ]]; then
+    echo "Bootlet zImage not found, getting one from S3"
+    wget -o "$BOOTLET_ZIMAGE" http://fw-releases.wirenboard.com/utils/build-image/zImage.wb7
+fi


### PR DESCRIPTION
В сочетании с https://github.com/wirenboard/wirenboard/pull/144 (уже влит) гарантирует установку самой последней версии бутлета из S3. В будущем бутлет можно будет устанавливать как пакет