### PR TITLE
wb-image-update: fix zImage download during rootfs creation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.9.2) stable; urgency=medium
+
+  * wb-image-update: fix zImage download during rootfs creation
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Mon, 01 May 2023 18:19:46 +0600
+
 wb-utils (4.9.1) stable; urgency=medium
 
   * wb-image-update: get FIT bootlet during rootfs creation

--- a/utils/bin/wb-watch-update
+++ b/utils/bin/wb-watch-update
@@ -115,7 +115,7 @@ while read EVENT_DIR EVENT_TYPE EVENT_FILE; do
 
 	# skip install_update.flags file event, it may be used for debugging
 	case "$FIT" in
-	*install_update.*|)
+	*install_update.*)
 		continue
 		;;
 	esac

--- a/utils/lib/wb-image-update/fit/build.sh
+++ b/utils/lib/wb-image-update/fit/build.sh
@@ -92,6 +92,12 @@ echo "+single-rootfs " > /var/lib/wb-image-update/firmware-compatible
 # FIXME: install bootlet image as deb package
 BOOTLET_ZIMAGE=/var/lib/wb-image-update/zImage
 if [[ ! -e "$BOOTLET_ZIMAGE" ]]; then
+    BOOTLET_URL="http://fw-releases.wirenboard.com/utils/build-image/zImage.wb7"
+    SHA256_URL="$BOOTLET_URL.sha256"
+
     echo "Bootlet zImage not found, getting one from S3"
     wget -O "$BOOTLET_ZIMAGE" http://fw-releases.wirenboard.com/utils/build-image/zImage.wb7
+
+    echo "Checking SHA256 sum"
+    echo "$(wget -O- "$SHA256_URL")  $BOOTLET_ZIMAGE" | sha256sum -c
 fi

--- a/utils/lib/wb-image-update/fit/build.sh
+++ b/utils/lib/wb-image-update/fit/build.sh
@@ -93,5 +93,5 @@ echo "+single-rootfs " > /var/lib/wb-image-update/firmware-compatible
 BOOTLET_ZIMAGE=/var/lib/wb-image-update/zImage
 if [[ ! -e "$BOOTLET_ZIMAGE" ]]; then
     echo "Bootlet zImage not found, getting one from S3"
-    wget -o "$BOOTLET_ZIMAGE" http://fw-releases.wirenboard.com/utils/build-image/zImage.wb7
+    wget -O "$BOOTLET_ZIMAGE" http://fw-releases.wirenboard.com/utils/build-image/zImage.wb7
 fi


### PR DESCRIPTION
Почему-то проморгал проблему с новыми FIT, в которых вместо ядра оказался лог его загрузки