### PR TITLE
add more info about broken FIT image, allow offline updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,9 @@ install: build_mass_storage
 		utils/bin/wb-watch-update \
 		utils/bin/wb-run-update
 
+	install -Dm0755 -t $(IMAGEUPDATE_DIR) \
+		utils/lib/wb-image-update/fix-broken-fit.sh
+
 	install -Dm0755 -t $(IMAGEUPDATE_POSTINST_DIR) \
 		utils/lib/wb-image-update/postinst/10update-u-boot
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.9.5) stable; urgency=medium
+
+  * add more info about broken FIT image, allow offline updates
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 02 May 2023 20:49:11 +0600
+
 wb-utils (4.9.4) stable; urgency=medium
 
   * do not fail during rootfs build explicitly

--- a/debian/postinst
+++ b/debian/postinst
@@ -9,48 +9,10 @@ fi
 
 /usr/lib/wb-utils/prepare/wb-prepare.sh fix_hosts
 
-. /usr/lib/wb-utils/wb_env.sh
-wb_source "of"
-
-if of_machine_match "wirenboard,wirenboard-720"; then
-    # replace broken factoryreset FITs
-    FACTORYRESET_FIT="/mnt/data/.wb-restore/factoryreset.fit"
-
-    # do not fail during rootfs build
-    if [ -e "$FACTORYRESET_FIT" ]; then
-        FACTORYRESET_SHA256="$(sha256sum "$FACTORYRESET_FIT" | awk '{print $1}')"
-
-        BROKEN_STABLE_FITS=(
-            "7ca056ba02c24f882283d16a0c0ee4cc2c0a92cd509fabb89021cb5305b61a3a"
-            "9ef0b4ac68d0c839a6ee59788a6230a3a21988472b006a6e37f4f1b6cfe73cc7"
-            "82618e593e59fa571c298d64e596188df5877ead0207a9611eee1a5c4f5036d9"
-            "b5e21070b69a0a258471c12f199f5f52c4d455b0cc5fbed7c4d2b055b21beccb"
-        )
-
-        BROKEN_TESTING_FITS=(
-            "edd8d2735dbd3d7b616eea64fab6ff4acf7c3729e27a4085576d60c843b280b1"
-        )
-
-        download_fixed_fit() {
-            URL="$1"
-            shift
-            for broken in "$@"; do
-                if [[ "$FACTORYRESET_SHA256" == "$broken" ]]; then
-                    echo "Broken factory FIT found, downloading a working one"
-                    wget -O "${FACTORYRESET_FIT}.new" "${URL}?broken&from=${FACTORYRESET_SHA256}&serial=$(wb-gen-serial -s)"
-                    mv "${FACTORYRESET_FIT}.new" "$FACTORYRESET_FIT"
-                    sync
-                    break
-                fi
-            done
-        }
-
-        STABLE_FIT_URL="https://fw-releases.wirenboard.com/fit_image/stable/7x/latest.fit"
-        download_fixed_fit "$STABLE_FIT_URL" "${BROKEN_STABLE_FITS[@]}"
-
-        TESTING_FIT_URL="https://fw-releases.wirenboard.com/fit_image/testing/7x/latest.fit"
-        download_fixed_fit "$TESTING_FIT_URL" "${BROKEN_TESTING_FITS[@]}"
-    fi
-fi
+/usr/lib/wb-image-update/fix-broken-fit.sh || {
+    >&2 echo -e "\nFailed to fix factory FIT (maybe we are offline?)"
+    >&2 echo -e "You can try again later by calling 'apt install --reinstall wb-utils'.\n"
+    >&2 echo -e "For further information see https://wirenboard.com/wiki/WB_7:_Errata#ERRWB73009\n"
+}
 
 exit 0

--- a/utils/lib/wb-image-update/fix-broken-fit.sh
+++ b/utils/lib/wb-image-update/fix-broken-fit.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e
+
+. /usr/lib/wb-utils/wb_env.sh
+wb_source "of"
+
+if of_machine_match "wirenboard,wirenboard-720"; then
+    # replace broken factoryreset FITs
+    FACTORYRESET_FIT="/mnt/data/.wb-restore/factoryreset.fit"
+
+    # do not fail during rootfs build
+    if [ -e "$FACTORYRESET_FIT" ]; then
+        FACTORYRESET_SHA256="$(sha256sum "$FACTORYRESET_FIT" | awk '{print $1}')"
+
+        BROKEN_STABLE_FITS=(
+            "7ca056ba02c24f882283d16a0c0ee4cc2c0a92cd509fabb89021cb5305b61a3a"
+            "9ef0b4ac68d0c839a6ee59788a6230a3a21988472b006a6e37f4f1b6cfe73cc7"
+            "82618e593e59fa571c298d64e596188df5877ead0207a9611eee1a5c4f5036d9"
+            "b5e21070b69a0a258471c12f199f5f52c4d455b0cc5fbed7c4d2b055b21beccb"
+        )
+
+        BROKEN_TESTING_FITS=(
+            "edd8d2735dbd3d7b616eea64fab6ff4acf7c3729e27a4085576d60c843b280b1"
+        )
+
+        download_fixed_fit() {
+            URL="$1"
+            shift
+            for broken in "$@"; do
+                if [[ "$FACTORYRESET_SHA256" == "$broken" ]]; then
+                    echo "Broken factory FIT found, downloading a working one"
+                    wget -O "${FACTORYRESET_FIT}.new" "${URL}?broken&from=${FACTORYRESET_SHA256}&serial=$(wb-gen-serial -s)"
+                    mv "${FACTORYRESET_FIT}.new" "$FACTORYRESET_FIT"
+                    sync
+                    break
+                fi
+            done
+        }
+
+        STABLE_FIT_URL="https://fw-releases.wirenboard.com/fit_image/stable/7x/latest.fit"
+        download_fixed_fit "$STABLE_FIT_URL" "${BROKEN_STABLE_FITS[@]}"
+
+        TESTING_FIT_URL="https://fw-releases.wirenboard.com/fit_image/testing/7x/latest.fit"
+        download_fixed_fit "$TESTING_FIT_URL" "${BROKEN_TESTING_FITS[@]}"
+    fi
+fi

--- a/utils/lib/wb-image-update/fix-broken-fit.sh
+++ b/utils/lib/wb-image-update/fix-broken-fit.sh
@@ -5,7 +5,10 @@ set -e
 . /usr/lib/wb-utils/wb_env.sh
 wb_source "of"
 
-if of_machine_match "wirenboard,wirenboard-720"; then
+# FIXME: wirenboard,wirenboard-720 is obsolete, use wirenboard,wirenboard-7xx instead.
+# It requires wirenboard-7xx entries in older DTS.
+# See https://wirenboard.bitrix24.ru/workgroups/group/218/tasks/task/view/61070/
+if of_machine_match "wirenboard,wirenboard-7xx" || of_machine_match "wirenboard,wirenboard-720"; then
     # replace broken factoryreset FITs
     FACTORYRESET_FIT="/mnt/data/.wb-restore/factoryreset.fit"
 


### PR DESCRIPTION
Поговорил с @evgeny-boger, решили сделать возможность обновлять wb-utils в оффлайн-режиме, для этого процедура восстановления FIT переехала в отдельный скрипт и при падении не ломает установку, только выводит больше информации о том, как продолжить.