### PR TITLE
Fix wb-run-update from random location

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-utils (4.9.6) stable; urgency=medium
+
+  * fix FIT image install via wb-run-update with single rootfs from random
+    location
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Fri, 05 May 2023 12:58:34 +0600
+
 wb-utils (4.9.5) stable; urgency=medium
 
   * add more info about broken FIT image, allow offline updates

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -747,7 +747,21 @@ update_after_reboot() {
     mkdir -p "$(dirname "$UPDATE_STATUS_FILE")"
     mkdir -p "$(dirname "$UPDATE_LOG_FILE")"
 
-    mv "$FIT" "$WEBUPD_DIR/webupd.fit"
+    TARGET_UPDATE_FILE="$WEBUPD_DIR/webupd.fit"
+
+    if [[ "$TARGET_UPDATE_FILE" -ef "$FIT" ]]; then
+        if flag_set no-remove; then
+            # FIXME: pass --no-remove to bootlet via flags file
+            fatal "Flag --no-remove is ignored for $FIT, it is after-reboot FIT location"
+        fi
+    else
+        if flag_set no-remove; then
+            info "Flag --no-remove is set, keeping $FIT"
+            cp "$FIT" "$TARGET_UPDATE_FILE"
+        else
+            mv "$FIT" "$TARGET_UPDATE_FILE"
+        fi
+    fi
 
     # write error note by default in the update status file,
     # it will be overwritten if update script is started properly after reboot

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -98,7 +98,7 @@ prepare_env() {
         ln -s /proc/self/mounts /etc/mtab || true
     fi
 
-    UPDATE_DIR="$(dirname "$FIT")"
+    WEBUPD_DIR="/mnt/data/.wb-update"
 
     # FLAGS variable is defined in wb-run-update
     # This is a hack to pass more flags from installation media for debugging
@@ -110,11 +110,14 @@ prepare_env() {
     fi
 
 
-    UPDATE_STATUS_FILE="$UPDATE_DIR/state/update.status"
-    UPDATE_LOG_FILE="$UPDATE_DIR/state/update.log"
+    UPDATE_STATUS_FILE="$WEBUPD_DIR/state/update.status"
+    UPDATE_LOG_FILE="$WEBUPD_DIR/state/update.log"
 
     if flag_set from-webupdate; then
         info "Web UI-triggered update detected, forwarding logs and status to files"
+
+        mkdir -p "$(dirname "$UPDATE_STATUS_FILE")"
+        mkdir -p "$(dirname "$UPDATE_LOG_FILE")"
 
         mqtt_status() {
             echo "$*" >> "$UPDATE_LOG_FILE"
@@ -740,7 +743,11 @@ update_after_reboot() {
     info "Single rootfs scheme detected, reboot system to perform update"
     info "Waiting for Wiren Board to boot again..."
 
-    mv "$FIT" "$UPDATE_DIR/webupd.fit"
+    mkdir -p "$WEBUPD_DIR"
+    mkdir -p "$(dirname "$UPDATE_STATUS_FILE")"
+    mkdir -p "$(dirname "$UPDATE_LOG_FILE")"
+
+    mv "$FIT" "$WEBUPD_DIR/webupd.fit"
 
     # write error note by default in the update status file,
     # it will be overwritten if update script is started properly after reboot


### PR DESCRIPTION
Вызов `wb-run-update` вручную из произвольной локации был сломан для схемы с расширенным rootfs, этот патч должен починить это для новых фитов из testing. Не хочу добавлять логику в wb-run-update.

Проверил на одном и двух rootfs.