### PR TITLE
of: source wb_env cache

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
 wb-utils (4.10.0) stable; urgency=medium
 
-  * of: source wb_env cache
+  * of: evaluate gpiochips regardless of wb-env.cache
 
- -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 17 May 2023 01:12:19 +0300
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Mon, 29 May 2023 10:21:45 +0300
 
 wb-utils (4.9.7) stable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.10.0) stable; urgency=medium
+
+  * of: source wb_env cache
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 17 May 2023 01:12:19 +0300
+
 wb-utils (4.9.7) stable; urgency=medium
 
   * wb-gsm: add error message if modem is not configured

--- a/utils/lib/of.sh
+++ b/utils/lib/of.sh
@@ -220,9 +220,6 @@ of_find_gpiochips() {
 }
 fi #############################################################################
 
-# Evaluate gpiochips regardless of wb-env.cache
-of_find_gpiochips
-
 # Get compatible list of node, one item per line
 # Args:
 #	node
@@ -362,3 +359,6 @@ of_get_prop_gpionum() {
 
 	of_gpio_to_num $(of_get_prop_gpio "$1" "$2" | index "$index")
 }
+
+# Evaluate gpiochips regardless of wb-env.cache
+of_find_gpiochips

--- a/utils/lib/of.sh
+++ b/utils/lib/of.sh
@@ -2,12 +2,6 @@
 
 WB_ENV_CACHE="${WB_ENV_CACHE:-/var/run/wb_env.cache}"
 
-if [[ -f $WB_ENV_CACHE ]]; then
-    set -a
-    source "$WB_ENV_CACHE"
-    set +a
-fi
-
 bin2ulong() {
 	local -a bytes
 
@@ -227,6 +221,9 @@ of_find_gpiochips() {
 	done
 }
 fi #############################################################################
+
+# Evaluate gpiochips regardless of wb-env.cache
+of_find_gpiochips
 
 # Get compatible list of node, one item per line
 # Args:

--- a/utils/lib/of.sh
+++ b/utils/lib/of.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+WB_ENV_CACHE="${WB_ENV_CACHE:-/var/run/wb_env.cache}"
+
+if [[ -f $WB_ENV_CACHE ]]; then
+    set -a
+    source "$WB_ENV_CACHE"
+    set +a
+fi
+
 bin2ulong() {
 	local -a bytes
 
@@ -70,7 +78,7 @@ __of_node_path() {
 __of_get_prop() {
 	local node="$(__of_node_path "$1")"
 	local prop="$2"
-	
+
 	cat "$node/$prop"
 }
 
@@ -101,7 +109,7 @@ of_node_children() {
 #	name glob
 of_node_props() {
 	local node="$(__of_node_path "$1")"
-	
+
 	find "$node" -maxdepth 1 -type f \( ! -iname "name" \) -printf '%f\n'
 }
 
@@ -225,7 +233,7 @@ fi #############################################################################
 #	node
 of_node_compatible() {
 	local node="${1:-}"
-	
+
 	of_get_prop_str "$node" compatible
 }
 


### PR DESCRIPTION
Есть проблема: gpio-хелперы используют OF_GPIOCHIPS из env_кеша. В основном это работает, т.к. кеш подтягивается из bashrc; но работает не всегда. Решили явно подтягивать кеш; валидировать, думаю, не стоит, т.к. получим ад зависимостей

лечит вот это
![2023-05-17_01-32-03](https://github.com/wirenboard/wb-utils/assets/25829054/4709da82-d403-478f-a61a-eb99c195de76)
