### PR TITLE
ensure-env-cache: rework wb_env.cache validation (hash instead of mod…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.10.0) stable; urgency=medium
+
+  * ensure-env-cache: rework wb_env.cache validation (hash instead of modify-time)
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 17 May 2023 13:49:47 +0300
+
 wb-utils (4.9.7) stable; urgency=medium
 
   * wb-gsm: add error message if modem is not configured


### PR DESCRIPTION
…ify-time)

У нас давно были странные и непонятные проблемы с env_кешем. @webconn нашел, что время доступа к файлам в /proc/device-tree иногда меняется само по себе (почему - неясно) => механизм валидации кеша, основанный на этом, плохо работал.

Обсудили - решили переделать валидацию (автор идеи - @webconn)

Погонял у себя - разницы не заметил (как работало хорошо, так и работает)
У @KraPete и @Bugoon стало значительно быстрее 