### PR TITLE
wb-gsm: fix checking that a modem is controlled by ModemManager

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.11.1) stable; urgency=medium
+
+  * wb-gsm: fix checking that a modem is controlled by ModemManager
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Thu, 06 Jul 2023 16:32:05 +0500
+
 wb-utils (4.11.0) stable; urgency=medium
 
   * install_update.sh: add support for install_update.web.flags file and --force-repartition flag

--- a/utils/lib/wb-gsm-common.sh
+++ b/utils/lib/wb-gsm-common.sh
@@ -102,9 +102,12 @@ function is_driven_by_mm() {
 
     for portname in $usb_at_ports; do
         local udev_props=$(udevadm info -n $portname -q property)
-        if ! echo $udev_props | grep -q -e "ID_MM_PORT_IGNORE=1" -e "ID_MM_DEVICE_IGNORE=1"; then
-            debug "Modem ($portname) is possibly driven by ModemManager"
-            return 0
+        local exit_code=$?
+        if [[ exit_code == 0 ]]; then
+            if ! echo $udev_props | grep -q -e "ID_MM_PORT_IGNORE=1" -e "ID_MM_DEVICE_IGNORE=1"; then
+                debug "Modem ($portname) is possibly driven by ModemManager"
+                return 0
+            fi
         fi
     done
     debug "Modem is NOT driven by ModemManager"


### PR DESCRIPTION
If a port is broken udevadm can return an error. wb-gsm must check next port and must not show warning that the port is controlled by ModemManager

Логи тут https://wirenboard.bitrix24.ru/workgroups/group/218/tasks/task/view/61174/

Линукс теряет ttyACM0 после запуска модема. В логах ничего про USB нет.
На запрос к udevadm приходит ошибка
```
root@wirenboard-AGH767IU:~# udevadm info -n /dev/ttyACM0 -q property
Unknown device "/dev/ttyACM0": Inappropriate ioctl for device
```
Причём все остальные ttyACMx - рабочие
Перезапуском модема по питанию не лечится. Лечится только так
```
modprobe -r cdc_acm
rm -f /dev/ttyACM0
modprobe cdc_acm
```
Это воспроизводится на одном контроллере и не воспроизводится на другом.
Сделал проверку того, что udevadm завершился без ошибки, только тогда можно считать, что порт возможно управляется через MM.