### PR TITLE
Large rootfs support for WB6

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.12.0) stable; urgency=medium
+
+  * add extended rootfs support for wb6
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Thu, 13 Jul 2023 19:10:15 +0600
+
 wb-utils (4.11.2) stable; urgency=medium
 
   * wb-gsm: fix generation of serial number for WB6 with modem

--- a/debian/control
+++ b/debian/control
@@ -13,5 +13,6 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, lsb-base (>= 4.1), u-boot-tools-wb 
          linux-image-wb2 (>= 4.9+wb20180808183130) | linux-image-wb6 (>= 5.10.35-wb108~~) | linux-image-wb7 (>= 5.10.35-wb130~~),
          device-tree-compiler, parted, rsync, systemd (>= 243)
 Conflicts: wb-configs (<< 1.69.4)
-Breaks: wb-homa-ism-radio (<< 1.17.2), wb-rules-system (<< 1.6.1), wb-mqtt-serial (<< 1.47.2), wb-mqtt-homeui (<< 1.7.1), u-boot-wb7 (<< 2:2021.10+wb1.5.0~~)
+Breaks: wb-homa-ism-radio (<< 1.17.2), wb-rules-system (<< 1.6.1), wb-mqtt-serial (<< 1.47.2), wb-mqtt-homeui (<< 1.7.1),
+        u-boot-wb7 (<< 2:2021.10+wb1.5.0~~), u-boot-wb6 (<< 2:2021.10+wb1.6.0~~)
 Description: Wiren Board command-line utils

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -67,58 +67,6 @@ led_prompt() {
 	led red delay_off 100
 }
 
-flag_set no-mqtt && {
-	mqtt_status() { :; }
-
-	mqtt_progress() {
-		while read x; do
-			echo -en "\rPROGRESS: $x%"
-		done
-		echo
-	}
-
-	prompt_update_factoryreset() {
-		led_prompt
-		>&2 cat <<EOF
-##############################################################################
-
-                          FACTORY RESET REQUESTED
-
-           This WILL destroy ALL YOUR DATA: configuration, scripts,
-                           files in home directory!
-
-         If you are ABSOLUTELY SURE that you want to reset Wiren Board
-             to factory condition, hold the FW button for 4 seconds.
-
-        If you will not do it in 10 seconds, the controller will reboot
-                        without firmware update.
-
-
-           If you want to perform a regular firmware update, rename
-         FIT file to "wbX_update.fit" without "factory-reset" suffix.
-
-##############################################################################
-EOF
-		USE_BUZZER=y USE_ECHO=y WAIT_TIME=10 HOLD_TIME=4 wait_for_button 1>&2
-		local result=$?
-		led_process
-		return $result
-	}
-
-} || {
-	mqtt_status() {
-		mosquitto_pub -t /firmware/status -r -m "$*" 2>/dev/null >/dev/null || true
-	}
-
-	mqtt_progress() {
-		mosquitto_pub -t /firmware/progress -l 2>/dev/null >/dev/null || true
-	}
-
-	prompt_update_factoryreset() {
-		# TODO: upgrade with factory reset from Web interface
-		true
-	}
-}
 
 mkfs_ext4() {
 	local part=$1
@@ -243,6 +191,59 @@ while [[ -n "$1" ]]; do
 done
 
 [[ -f "$FIT" ]] || die "FIT $FIT not found"
+
+flag_set no-mqtt && {
+	mqtt_status() { :; }
+
+	mqtt_progress() {
+		while read x; do
+			echo -en "\rPROGRESS: $x%"
+		done
+		echo
+	}
+
+	prompt_update_factoryreset() {
+		led_prompt
+		>&2 cat <<EOF
+##############################################################################
+
+                          FACTORY RESET REQUESTED
+
+           This WILL destroy ALL YOUR DATA: configuration, scripts,
+                           files in home directory!
+
+         If you are ABSOLUTELY SURE that you want to reset Wiren Board
+             to factory condition, hold the FW button for 4 seconds.
+
+        If you will not do it in 10 seconds, the controller will reboot
+                        without firmware update.
+
+
+           If you want to perform a regular firmware update, rename
+         FIT file to "wbX_update.fit" without "factory-reset" suffix.
+
+##############################################################################
+EOF
+		USE_BUZZER=y USE_ECHO=y WAIT_TIME=10 HOLD_TIME=4 wait_for_button 1>&2
+		local result=$?
+		led_process
+		return $result
+	}
+
+} || {
+	mqtt_status() {
+		mosquitto_pub -t /firmware/status -r -m "$*" 2>/dev/null >/dev/null || true
+	}
+
+	mqtt_progress() {
+		mosquitto_pub -t /firmware/progress -l 2>/dev/null >/dev/null || true
+	}
+
+	prompt_update_factoryreset() {
+		# TODO: upgrade with factory reset from Web interface
+		true
+	}
+}
 
 flag_set no-mqtt && {
 	# check factory reset condition here and add flag in this case

--- a/utils/lib/wb-image-update/fit/build.sh
+++ b/utils/lib/wb-image-update/fit/build.sh
@@ -21,7 +21,7 @@ fi
 . /usr/lib/wb-utils/wb_env.sh
 wb_source "of"
 
-if of_machine_match "wirenboard,wirenboard-720"; then
+if of_machine_match "wirenboard,wirenboard-7xx" || of_machine_match "wirenboard,wirenboard-720"; then
     TARGET=wb7
 elif of_machine_match "contactless,imx6ul-wirenboard60"; then
     TARGET=wb6

--- a/utils/lib/wb-image-update/fit/build.sh
+++ b/utils/lib/wb-image-update/fit/build.sh
@@ -95,7 +95,6 @@ echo -n "+single-rootfs " > /var/lib/wb-image-update/firmware-compatible
 echo -n "+force-repartition " >> /var/lib/wb-image-update/firmware-compatible
 
 # FIXME: install bootlet image as deb package
-if [[ "$TARGET" == "wb7" ]]; then
 BOOTLET_ZIMAGE=/var/lib/wb-image-update/zImage
 if [[ ! -e "$BOOTLET_ZIMAGE" ]]; then
     BOOTLET_URL="http://fw-releases.wirenboard.com/utils/build-image/zImage.$TARGET"
@@ -106,5 +105,4 @@ if [[ ! -e "$BOOTLET_ZIMAGE" ]]; then
 
     echo "Checking SHA256 sum"
     echo "$(wget -O- "$SHA256_URL")  $BOOTLET_ZIMAGE" | sha256sum -c
-fi
 fi

--- a/utils/lib/wb-image-update/fit/build.sh
+++ b/utils/lib/wb-image-update/fit/build.sh
@@ -21,7 +21,11 @@ fi
 . /usr/lib/wb-utils/wb_env.sh
 wb_source "of"
 
-if ! of_machine_match "wirenboard,wirenboard-720"; then
+if of_machine_match "wirenboard,wirenboard-720"; then
+    TARGET=wb7
+elif of_machine_match "contactless,imx6ul-wirenboard60"; then
+    TARGET=wb6
+else
     echo "Single rootfs scheme is not supported on this target, skipping install_update.sh build"
     exit 0
 fi
@@ -93,11 +97,11 @@ echo "+force-repartition " >> /var/lib/wb-image-update/firmware-compatible
 # FIXME: install bootlet image as deb package
 BOOTLET_ZIMAGE=/var/lib/wb-image-update/zImage
 if [[ ! -e "$BOOTLET_ZIMAGE" ]]; then
-    BOOTLET_URL="http://fw-releases.wirenboard.com/utils/build-image/zImage.wb7"
+    BOOTLET_URL="http://fw-releases.wirenboard.com/utils/build-image/zImage.$TARGET"
     SHA256_URL="$BOOTLET_URL.sha256"
 
     echo "Bootlet zImage not found, getting one from S3"
-    wget -O "$BOOTLET_ZIMAGE" http://fw-releases.wirenboard.com/utils/build-image/zImage.wb7
+    wget -O "$BOOTLET_ZIMAGE" "$BOOTLET_URL"
 
     echo "Checking SHA256 sum"
     echo "$(wget -O- "$SHA256_URL")  $BOOTLET_ZIMAGE" | sha256sum -c

--- a/utils/lib/wb-image-update/fit/build.sh
+++ b/utils/lib/wb-image-update/fit/build.sh
@@ -94,15 +94,21 @@ cd "$BUILDDIR" && tar cvzf /var/lib/wb-image-update/deps.tar.gz .
 echo -n "+single-rootfs " > /var/lib/wb-image-update/firmware-compatible
 echo -n "+force-repartition " >> /var/lib/wb-image-update/firmware-compatible
 
-# FIXME: install bootlet image as deb package
-BOOTLET_ZIMAGE=/var/lib/wb-image-update/zImage
-if [[ ! -e "$BOOTLET_ZIMAGE" ]]; then
-    BOOTLET_URL="http://fw-releases.wirenboard.com/utils/build-image/zImage.$TARGET"
-    SHA256_URL="$BOOTLET_URL.sha256"
+# FIXME: install bootlet image and DTB as deb package
+download_bootlet_file() {
+    local FILE=$1
+    local FILEPATH="/var/lib/wb-image-update/$FILE.$TARGET"
+    if [[ ! -e "$FILEPATH" ]]; then
+        BOOTLET_URL="http://fw-releases.wirenboard.com/utils/build-image/$FILE.$TARGET"
+        SHA256_URL="$BOOTLET_URL.sha256"
 
-    echo "Bootlet zImage not found, getting one from S3"
-    wget -O "$BOOTLET_ZIMAGE" "$BOOTLET_URL"
+        echo "Bootlet $FILE not found, getting one from S3"
+        wget -O "$FILEPATH" "$BOOTLET_URL"
 
-    echo "Checking SHA256 sum"
-    echo "$(wget -O- "$SHA256_URL")  $BOOTLET_ZIMAGE" | sha256sum -c
-fi
+        echo "Checking SHA256 sum"
+        echo "$(wget -O- "$SHA256_URL")  $FILEPATH" | sha256sum -c
+    fi
+}
+
+download_bootlet_file zImage
+download_bootlet_file boot.dtb

--- a/utils/lib/wb-image-update/fit/build.sh
+++ b/utils/lib/wb-image-update/fit/build.sh
@@ -97,7 +97,7 @@ echo -n "+force-repartition " >> /var/lib/wb-image-update/firmware-compatible
 # FIXME: install bootlet image and DTB as deb package
 download_bootlet_file() {
     local FILE=$1
-    local FILEPATH="/var/lib/wb-image-update/$FILE.$TARGET"
+    local FILEPATH="/var/lib/wb-image-update/$FILE"
     if [[ ! -e "$FILEPATH" ]]; then
         BOOTLET_URL="http://fw-releases.wirenboard.com/utils/build-image/$FILE.$TARGET"
         SHA256_URL="$BOOTLET_URL.sha256"
@@ -106,7 +106,7 @@ download_bootlet_file() {
         wget -O "$FILEPATH" "$BOOTLET_URL"
 
         echo "Checking SHA256 sum"
-        echo "$(wget -O- "$SHA256_URL")  $FILEPATH" | sha256sum -c
+        echo "$(wget -O- "$SHA256_URL") $FILEPATH" | sha256sum -c
     fi
 }
 

--- a/utils/lib/wb-image-update/fit/build.sh
+++ b/utils/lib/wb-image-update/fit/build.sh
@@ -91,10 +91,11 @@ mkdir -p /var/lib/wb-image-update
 cp /usr/lib/wb-image-update/fit/install_update.sh /var/lib/wb-image-update/install_update.sh
 cd "$BUILDDIR" && tar cvzf /var/lib/wb-image-update/deps.tar.gz .
 
-echo "+single-rootfs " > /var/lib/wb-image-update/firmware-compatible
-echo "+force-repartition " >> /var/lib/wb-image-update/firmware-compatible
+echo -n "+single-rootfs " > /var/lib/wb-image-update/firmware-compatible
+echo -n "+force-repartition " >> /var/lib/wb-image-update/firmware-compatible
 
 # FIXME: install bootlet image as deb package
+if [[ "$TARGET" == "wb7" ]]; then
 BOOTLET_ZIMAGE=/var/lib/wb-image-update/zImage
 if [[ ! -e "$BOOTLET_ZIMAGE" ]]; then
     BOOTLET_URL="http://fw-releases.wirenboard.com/utils/build-image/zImage.$TARGET"
@@ -105,4 +106,5 @@ if [[ ! -e "$BOOTLET_ZIMAGE" ]]; then
 
     echo "Checking SHA256 sum"
     echo "$(wget -O- "$SHA256_URL")  $BOOTLET_ZIMAGE" | sha256sum -c
+fi
 fi

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -478,7 +478,7 @@ cleanup_rootfs() {
 ensure_uboot_ready_for_webupd() {
     local version
     version=$(awk '{ print $2 }' /proc/device-tree/chosen/u-boot-version | sed 's/-g[0-9a-f]\+$//')
-    if dpkg --compare-versions "$version" lt "2021.10-wb1.5.0~~"; then
+    if dpkg --compare-versions "$version" lt "2021.10-wb1.6.0~~"; then
         info "Flashed U-boot version is too old, updating it before reboot"
         u-boot-install-wb -f || fatal "Failed to update U-boot"
     fi

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -687,7 +687,11 @@ maybe_update_current_factory_fit() {
     # check if current fit supports +single-rootfs feature
     CURRENT_FACTORY_FIT="$mnt/.wb-restore/factoryreset.fit"
 
-    if ! FIT="$CURRENT_FACTORY_FIT" fw_compatible single-rootfs; then
+    if [[ ! -e "$CURRENT_FACTORY_FIT" ]]; then
+        info "No factory FIT found, storing this update as factory FIT to use as bootlet"
+        mkdir -p "$mnt/.wb-restore"
+        cp "$FIT" "$mnt/.wb-restore/factoryreset.fit"
+    elif ! FIT="$CURRENT_FACTORY_FIT" fw_compatible single-rootfs; then
         info "Storing this update as factory FIT to use as bootlet"
         info "Old factory FIT will be kept as factoryreset.original.fit and will still be used to restore firmware"
 


### PR DESCRIPTION
 - up u-boot version (https://github.com/wirenboard/u-boot-private/pull/40)
 - fix wb-run-update script in bootlet (factory reset confirmation was broken)
 - download both bootlet and DTS from S3
 - fix factory FIT installation during Web UI update