### PR TITLE
Fix 2G modems initialization on WB6

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.14.1) stable; urgency=medium
+
+  * Fix 2G modems initialization on WB6
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 07 Aug 2023 11:16:31 +0500
+
 wb-utils (4.14.0) stable; urgency=medium
 
   * wb-gen-serial: look into standart Linux place

--- a/utils/lib/wb-gsm-common.sh
+++ b/utils/lib/wb-gsm-common.sh
@@ -14,7 +14,16 @@ OF_GSM_NODE="wirenboard/gsm"  # deprecated since default modem's connection is u
 function guess_of_node() {
     # default modem's connection is usb (with modem node on specific port)
     # wirenboard/gsm node is left for uart-only-modems compatibility
-    of_has_prop "aliases" "wbc_modem" && OF_GSM_NODE=$(of_get_prop_str "aliases" "wbc_modem") || OF_GSM_NODE="wirenboard/gsm"
+    OF_GSM_NODE="wirenboard/gsm"
+    if of_node_exists $OF_GSM_NODE; then
+        if [[ $(of_get_prop_str $OF_GSM_NODE "status") == "okay" ]]; then
+            debug "Got of_gsm_node: $OF_GSM_NODE"
+            return 0
+        fi
+    fi
+    if of_has_prop "aliases" "wbc_modem"; then
+        OF_GSM_NODE=$(of_get_prop_str "aliases" "wbc_modem")
+    fi
     debug "Got of_gsm_node: $OF_GSM_NODE"
 }
 


### PR DESCRIPTION
First check wirenboard/gsm status, next check USB modems


DTS WB6 имеет оба узла и `wirenboard/gsm`, и `wbc-modem`. Старая процедура определения с каким узлом работать, видела wbc-modem и использовала его, несмотря на то, что 2G модем включен в wirenboard/gsm. Теперь сначала проверяем status  в wirenboard/gsm, а потом wbc-modem