### PR TITLE
WBEC support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ install: build_mass_storage
 
 	install -Dm0755 -t $(LIBDIR) \
 		utils/lib/wb-init.sh \
-		utils/lib/ensure-env-cache.sh
+		utils/lib/ensure-env-cache.sh \
+		utils/lib/device-factory-fdt.sh
 
 	install -Dm0655 -t $(PREPARE_LIBDIR) \
 		utils/lib/prepare/partitions.sh \
@@ -59,7 +60,8 @@ install: build_mass_storage
 		utils/lib/wb-image-update/fix-broken-fit.sh
 
 	install -Dm0755 -t $(IMAGEUPDATE_POSTINST_DIR) \
-		utils/lib/wb-image-update/postinst/10update-u-boot
+		utils/lib/wb-image-update/postinst/10update-u-boot \
+		utils/lib/wb-image-update/postinst/10update-wbec-firmware
 
 	install -Dm0755 -t $(FIT_FILES_DIR) \
 		utils/lib/wb-image-update/fit/build.sh \

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.15.0) stable; urgency=medium
+
+  * Install WBEC firmware on factory reset
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 09 Aug 2023 21:34:35 +0600
+
 wb-utils (4.14.2) stable; urgency=medium
 
   * Fix deb package build. No functional changes

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, lsb-base (>= 4.1), u-boot-tools-wb (>= 2015.07+wb-3), inotify-tools, pv, jq,
          nginx-extras, python3-wb-common (>= 2.0.0~~), wb-configs (>= 3.18.0~~), util-linux,
          linux-image-wb2 (>= 4.9+wb20180808183130) | linux-image-wb6 (>= 5.10.35-wb108~~) | linux-image-wb7 (>= 5.10.35-wb130~~),
-         device-tree-compiler, parted, rsync, systemd (>= 243)
+         device-tree-compiler, parted, rsync, systemd (>= 243), wb-ec-firmware
 Conflicts: wb-configs (<< 1.69.4)
 Breaks: wb-homa-ism-radio (<< 1.17.2), wb-rules-system (<< 1.6.1), wb-mqtt-serial (<< 1.47.2), wb-mqtt-homeui (<< 1.7.1),
         u-boot-wb7 (<< 2:2021.10+wb1.5.0~~), u-boot-wb6 (<< 2:2021.10+wb1.6.0~~)

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -176,7 +176,8 @@ check_firmware_compatible() {
     fi
 
     if ! fw_has_proper_dtb; then
-        die "Firmware is not compatible with this device"
+        info "This firmware is too old for this device, please use newer one from https://fw-releases.wirenboard.com/"
+        die "Firmware is not compatible with this device, no proper DTB found"
     fi
 
     if ! disk_layout_is_ab && ! fw_compatible "single-rootfs"; then

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -162,10 +162,21 @@ fw_compatible() {
     esac
 }
 
+fw_has_proper_dtb() {
+    local dtb_name
+    dtb_name=$(/usr/lib/wb-utils/device-factory-fdt.sh)
+
+    fit_blob_data rootfs | tar tz | grep -q -m1 -F "$dtb_name"
+}
+
 check_firmware_compatible() {
     if flag_set force-fw-compatible; then
         info "Firmware compatibility check skipped"
         return
+    fi
+
+    if ! fw_has_proper_dtb; then
+        die "Firmware is not compatible with this device"
     fi
 
     if ! disk_layout_is_ab && ! fw_compatible "single-rootfs"; then

--- a/utils/lib/device-factory-fdt.sh
+++ b/utils/lib/device-factory-fdt.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This script extracts device model from factory overlay and prints it to stdout.
+# It works even in bootlet environment, so it can be used in install_update.sh.
+
+set -e
+
+EMMC=${EMMC:-/dev/mmcblk0}
+TMPFILE=$(mktemp)
+trap 'rm -f $TMPFILE' EXIT
+
+# creating empty DTB to apply overlay to
+echo "/dts-v1/; / { wirenboard {}; };" | dtc -I dts -O dtb -o "$TMPFILE"
+dd "if=$EMMC" bs=512 skip=2016 count=32 | fdtoverlay -i "$TMPFILE" -o - - | fdtget -t s - /wirenboard factory-fdt

--- a/utils/lib/wb-image-update/fit/build.sh
+++ b/utils/lib/wb-image-update/fit/build.sh
@@ -22,7 +22,7 @@ fi
 wb_source "of"
 
 if of_machine_match "wirenboard,wirenboard-7xx" || of_machine_match "wirenboard,wirenboard-720"; then
-    TARGET=wb7
+    TARGET=wb74  # FIXME
 elif of_machine_match "contactless,imx6ul-wirenboard60"; then
     TARGET=wb6
 else

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -155,6 +155,18 @@ prepare_env() {
         fi
     fi
 
+    if flag_set console-log; then
+        FINAL_CONSOLE_LOG_FILE="$(dirname "$FIT")/console.log"
+        TEMP_LOG_FILE="$(mktemp)"
+
+        if touch "$FINAL_CONSOLE_LOG_FILE" && [[ -w "$FINAL_CONSOLE_LOG_FILE" ]]; then
+            exec > >(tee "$TEMP_LOG_FILE") 2>&1
+            trap_add "cat '$TEMP_LOG_FILE' >> '$FINAL_CONSOLE_LOG_FILE'; rm '$TEMP_LOG_FILE'" EXIT
+
+            info "Console logging enabled; tempfile $TEMP_LOG_FILE, final file $FINAL_CONSOLE_LOG_FILE will be written on exit"
+        fi
+    fi
+
     type fit_prop_string 2>/dev/null | grep -q 'shell function' || {
         fit_prop_string() {
             fit_prop "$@" | tr -d '\0'

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -160,8 +160,8 @@ prepare_env() {
         fi
     fi
 
-    if flag_set console-log; then
-        FINAL_CONSOLE_LOG_FILE="$(dirname "$FIT")/console.log"
+    if ! flag_set no-console-log; then
+        FINAL_CONSOLE_LOG_FILE="$(dirname "$FIT")/wb-console.log"
         TEMP_LOG_FILE="$(mktemp)"
 
         if touch "$FINAL_CONSOLE_LOG_FILE" && [[ -w "$FINAL_CONSOLE_LOG_FILE" ]]; then

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -98,6 +98,11 @@ prepare_env() {
         ln -s /proc/self/mounts /etc/mtab || true
     fi
 
+    if [ ! -e /sys/kernel/config/device-tree ]; then
+        mkdir -p /sys/kernel/config
+        mount -t configfs configfs /sys/kernel/config
+    fi
+
     WEBUPD_DIR="/mnt/data/.wb-update"
 
     # FLAGS variable is defined in wb-run-update
@@ -161,7 +166,7 @@ prepare_env() {
 
         if touch "$FINAL_CONSOLE_LOG_FILE" && [[ -w "$FINAL_CONSOLE_LOG_FILE" ]]; then
             exec > >(tee "$TEMP_LOG_FILE") 2>&1
-            trap_add "cat '$TEMP_LOG_FILE' >> '$FINAL_CONSOLE_LOG_FILE'; rm '$TEMP_LOG_FILE'" EXIT
+            trap_add "cat '$TEMP_LOG_FILE' >> '$FINAL_CONSOLE_LOG_FILE'; rm '$TEMP_LOG_FILE; sync; sync'" EXIT
 
             info "Console logging enabled; tempfile $TEMP_LOG_FILE, final file $FINAL_CONSOLE_LOG_FILE will be written on exit"
         fi
@@ -661,6 +666,7 @@ run_postinst() {
     mount -o bind /dev "$ROOTFS_MNT/dev"
     mount -o bind /proc "$ROOTFS_MNT/proc"
     mount -o bind /sys "$ROOTFS_MNT/sys"
+    mount -o bind /sys/kernel/config "$ROOTFS_MNT/sys/kernel/config"
 
     POSTINST_DIR=${2:-"$ROOTFS_MNT/usr/lib/wb-image-update/postinst/"}
     if [[ -d "$POSTINST_DIR" ]]; then
@@ -676,6 +682,7 @@ run_postinst() {
     info "Unmounting /dev, /proc and /sys from rootfs"
     umount "$ROOTFS_MNT/dev"
     umount "$ROOTFS_MNT/proc"
+    umount "$ROOTFS_MNT/sys/kernel/config"
     umount "$ROOTFS_MNT/sys"
 }
 

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -662,7 +662,7 @@ run_postinst() {
     mount -o bind /proc "$ROOTFS_MNT/proc"
     mount -o bind /sys "$ROOTFS_MNT/sys"
 
-    POSTINST_DIR="$ROOTFS_MNT/usr/lib/wb-image-update/postinst/"
+    POSTINST_DIR=${2:-"$ROOTFS_MNT/usr/lib/wb-image-update/postinst/"}
     if [[ -d "$POSTINST_DIR" ]]; then
         info "Running post-install scripts"
 
@@ -882,6 +882,11 @@ fi
 
 if ! flag_set no-postinst; then
     run_postinst "$MNT"
+
+    if flag_set custom-postinst && [[ -d "$(dirname "$FIT")/install_update.postinst" ]]; then
+        info "Running custom postinst scripts from $(dirname "$FIT")/install_update.postinst"
+        run_postinst "$MNT" "$(dirname "$FIT")/install_update.postinst/"
+    fi
 fi
 
 if flag_set copy-to-factory; then

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -166,7 +166,7 @@ prepare_env() {
 
         if touch "$FINAL_CONSOLE_LOG_FILE" && [[ -w "$FINAL_CONSOLE_LOG_FILE" ]]; then
             exec > >(tee "$TEMP_LOG_FILE") 2>&1
-            trap_add "cat '$TEMP_LOG_FILE' >> '$FINAL_CONSOLE_LOG_FILE'; rm '$TEMP_LOG_FILE; sync; sync'" EXIT
+            trap_add "cat '$TEMP_LOG_FILE' >> '$FINAL_CONSOLE_LOG_FILE'; rm '$TEMP_LOG_FILE'; sync; sync" EXIT
 
             info "Console logging enabled; tempfile $TEMP_LOG_FILE, final file $FINAL_CONSOLE_LOG_FILE will be written on exit"
         fi

--- a/utils/lib/wb-image-update/postinst/10update-wbec-firmware
+++ b/utils/lib/wb-image-update/postinst/10update-wbec-firmware
@@ -1,0 +1,49 @@
+#!/bin/bash -e
+
+# Called from install_update.sh with arguments
+# /path/to/script /path/to/new/rootfs [flag1 [flag2 ...]]
+#
+# This script may run in Busybox initramfs environment,
+# so if you need some special tools or features, use ones from rootfs.
+#
+# /dev, /proc and /sys are already bind-mounted
+# from host system to rootfs tree.
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 path/to/rootfs [flag1 [flag2 ...]]"
+    exit 2
+fi
+
+ROOTFS="$1"
+shift
+FLAGS="$*"
+
+flag_set() {
+	echo "$FLAGS" | grep -- "--$1" >/dev/null 2>&1
+}
+
+if ! flag_set "factoryreset" ; then
+    echo "Skipping WBEC firmware update (use factory reset to do it)"
+    exit
+fi
+
+FDT_NAME=$(chroot "$ROOTFS" /usr/lib/wb-utils/device-factory-fdt.sh)
+FACTORY_DTB="/boot/dtbs/$FDT_NAME.dtb"
+
+if [ ! -f "$ROOTFS/$FACTORY_DTB" ]; then
+    echo "Cannot find factory DTB $FACTORY_DTB"
+    exit 1
+fi
+
+# extracting compatible property from factory DTB
+COMPATIBLE=$(chroot "$ROOTFS" fdtget -t s "$FACTORY_DTB" / compatible)
+
+case "$COMPATIBLE" in
+    *wirenboard,wirenboard-74x*)
+        echo "Trying to update WBEC firmware"
+        chroot "$ROOTFS" /bin/bash -c "export DTB=$FACTORY_DTB; /usr/bin/wb-ec-firmware-update"
+        ;;
+    *)
+        echo "This Wiren Board does not have WBEC, exiting"
+        ;;
+esac


### PR DESCRIPTION
До полноценного PR надо влить https://github.com/wirenboard/linux/pull/143 и https://github.com/wirenboard/wirenboard/pull/160, проверить, что бутлет корректно работает на предыдущих версиях WB7 и на WB7.4, и заменить основной бутлет на S3 на новый, после чего поправить в этом PR файл `build.sh` с wb74 обратно на wb7.

Этот патч добавляет обновление прошивки WBEC во время factory reset, а также добавляет пару отладочных флагов в скрипт установки FIT: 

-  `--console-log` - пишет весь вывод скрипта обновления в файл `console.log` рядом с FIT-файлом, полезно при удалённой отладке при прошивке через webupd;
- `--custom-postinst` - при добавлении этого флага в момент вызова postinst-скриптов из rootfs будут вызваны так же (и в таком же окружении) скрипты из директории `install_update.postinst` рядом с FIT-файлом. Полезно при отладке postinst-скриптов без пересборки образа.