### PR TITLE
Don't source wb_env.sh for wb-ts terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+## Wiren Board command-line utils

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.14.5) stable; urgency=medium
+
+  * Don't source wb_env.sh for wb-ts terminal
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 15 Aug 2023 18:23:00 +0400
+
 wb-utils (4.14.4) stable; urgency=medium
 
   * Fix broken rootfs enlargement on some devices with incorrect time

--- a/utils/lib/wb_env.sh
+++ b/utils/lib/wb_env.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+[[ "$LC_TERMINAL" = "wb-ts" ]] && return 0
+
 # unset all old variables with WB_ prefix beforehand
 for var in "${!WB_@}"; do unset "$var"; done
 


### PR DESCRIPTION
Для тестирования нам надо иметь возможность открывать ssh сессию без инициализации wb_env.sh, для этого предлагается проверять передаваемый `LC_TERMINAL` как отличительный признак тестовой сессии.