### PR TITLE
Check fit compatibility by dts presence + some debugging features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ install: build_mass_storage
 
 	install -Dm0755 -t $(LIBDIR) \
 		utils/lib/wb-init.sh \
-		utils/lib/ensure-env-cache.sh
+		utils/lib/ensure-env-cache.sh \
+		utils/lib/device-factory-fdt.sh
 
 	install -Dm0655 -t $(PREPARE_LIBDIR) \
 		utils/lib/prepare/partitions.sh \

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wb-utils (4.15.0) stable; urgency=medium
+
+  * wb-run-update: check new FIT compatibility by looking for DTB presence
+  * install_update.sh: add console logging, enabled by default
+  * install_update.sh: add custom postinst support (for debugging)
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Fri, 18 Aug 2023 17:04:10 +0600
+
 wb-utils (4.14.4) stable; urgency=medium
 
   * Fix broken rootfs enlargement on some devices with incorrect time

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -162,10 +162,22 @@ fw_compatible() {
     esac
 }
 
+fw_has_proper_dtb() {
+    local dtb_name
+    dtb_name=$(/usr/lib/wb-utils/device-factory-fdt.sh)
+
+    fit_blob_data rootfs | tar tz | grep -q -m1 -F "$dtb_name"
+}
+
 check_firmware_compatible() {
     if flag_set force-fw-compatible; then
         info "Firmware compatibility check skipped"
         return
+    fi
+
+    if ! fw_has_proper_dtb; then
+        info "This firmware is too old for this device, please use newer one from https://fw-releases.wirenboard.com/"
+        die "Firmware is not compatible with this device, no proper DTB found"
     fi
 
     if ! disk_layout_is_ab && ! fw_compatible "single-rootfs"; then

--- a/utils/lib/device-factory-fdt.sh
+++ b/utils/lib/device-factory-fdt.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This script extracts device model from factory overlay and prints it to stdout.
+# It works even in bootlet environment, so it can be used in install_update.sh.
+
+set -e
+
+EMMC=${EMMC:-/dev/mmcblk0}
+TMPFILE=$(mktemp)
+trap 'rm -f $TMPFILE' EXIT
+
+# creating empty DTB to apply overlay to
+echo "/dts-v1/; / { wirenboard {}; };" | dtc -I dts -O dtb -o "$TMPFILE"
+dd "if=$EMMC" bs=512 skip=2016 count=32 | fdtoverlay -i "$TMPFILE" -o - - | fdtget -t s - /wirenboard factory-fdt

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -690,7 +690,7 @@ run_postinst() {
     mount -o bind /proc "$ROOTFS_MNT/proc"
     mount -o bind /sys "$ROOTFS_MNT/sys"
 
-    POSTINST_DIR="$ROOTFS_MNT/usr/lib/wb-image-update/postinst/"
+    POSTINST_DIR=${2:-"$ROOTFS_MNT/usr/lib/wb-image-update/postinst/"}
     if [[ -d "$POSTINST_DIR" ]]; then
         info "Running post-install scripts"
 
@@ -910,6 +910,11 @@ fi
 
 if ! flag_set no-postinst; then
     run_postinst "$MNT"
+
+    if flag_set custom-postinst && [[ -d "$(dirname "$FIT")/install_update.postinst" ]]; then
+        info "Running custom postinst scripts from $(dirname "$FIT")/install_update.postinst"
+        run_postinst "$MNT" "$(dirname "$FIT")/install_update.postinst/"
+    fi
 fi
 
 if flag_set copy-to-factory; then

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -155,6 +155,18 @@ prepare_env() {
         fi
     fi
 
+    if ! flag_set no-console-log; then
+        FINAL_CONSOLE_LOG_FILE="$(dirname "$FIT")/wb-console.log"
+        TEMP_LOG_FILE="$(mktemp)"
+
+        if touch "$FINAL_CONSOLE_LOG_FILE" && [[ -w "$FINAL_CONSOLE_LOG_FILE" ]]; then
+            exec > >(tee "$TEMP_LOG_FILE") 2>&1
+            trap_add "cat '$TEMP_LOG_FILE' >> '$FINAL_CONSOLE_LOG_FILE'; rm '$TEMP_LOG_FILE'; sync; sync" EXIT
+
+            info "Console logging enabled; tempfile $TEMP_LOG_FILE, final file $FINAL_CONSOLE_LOG_FILE will be written on exit"
+        fi
+    fi
+
     type fit_prop_string 2>/dev/null | grep -q 'shell function' || {
         fit_prop_string() {
             fit_prop "$@" | tr -d '\0'


### PR DESCRIPTION
Этот PR - часть #115, которую надо влить отдельно. После этого надо собрать wb-initramfs, бутлет, и потом поддержку WBEC уже в этом репозитории.

Нужно для поддержки WB 7.4 на ранних этапах.

wb-run-update теперь проверяет совместимость FIT-файлов по наличию подходящего для этого устройства DTB в новой rootfs. Эта версия wb-run-update должна попасть в бутлет, чтобы проверка делалась и при обновлении с флешки или через USB.

Также в этом PR приложил пару полезных отладочных фич: запись лога установки в файл `wb-console.log` рядом с fit (пока не будет отключена явно флагом `--no-console-log`) и возможность использовать кастомные postinst-скрипты из директории `install-update.postinst` рядом с FIT, включается флагом `--custom-postinst`.