### PR TITLE
remove extra ROOTFS var from build.sh

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.17.2) stable; urgency=medium
+
+  * fix bootlet's build.sh in devenv builds; no functional changes
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Fri, 25 Aug 2023 14:42:01 +0600
+
 wb-utils (4.17.1) stable; urgency=medium
 
   * Don't source wb_env.sh for wb-ts terminal

--- a/utils/lib/wb-image-update/fit/build.sh
+++ b/utils/lib/wb-image-update/fit/build.sh
@@ -54,10 +54,10 @@ install_from_rootfs() {
                 dst="$src"
                 shift
         }
-        install_file "$ROOTFS/$src" "$dst"
+        install_file "$src" "$dst"
 
         # If file is executable, need to get its shared lib dependencies too
-        if [[ -x "$ROOTFS/$src" ]]; then
+        if [[ -x "$src" ]]; then
                 ldd "$src" |
                 sed -rn 's#[^/]*(/[^ ]*).*#\1#p' |
                 while read -r lib; do


### PR DESCRIPTION
Эти переменные `$ROOTFS` проскочили незамеченными копипастой из create_initramfs.sh, а при сборке devenv переменная определена, потому и бахнуло