### PR TITLE
wb-gen-serial: decode imei to fix wb6x sn-generating

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.17.3) stable; urgency=medium
+
+  * wb-gen-serial: decode imei to fix wb6x sn-generating
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Mon, 28 Aug 2023 12:36:12 +0300
+
 wb-utils (4.17.2) stable; urgency=medium
 
   * fix bootlet's build.sh in devenv builds; no functional changes

--- a/utils/bin/wb-gen-serial
+++ b/utils/bin/wb-gen-serial
@@ -128,6 +128,9 @@ def generate_serial_number():
     else:
         imei = ""
 
+    if isinstance(imei, bytes):
+        imei = imei.decode("utf-8")
+
     # read WB7 CPU serial from alternative source
     if dt_is_compatible(DT_SUNXI):
         cpuinfo_serial = str(get_wb7_cpu_serial())


### PR DESCRIPTION
переехали на пЕтон3 и поломали серийники на wb6x (где модем еще не модулем)

причина - subprocess, которым вытаскивается imei из модема, возвращает не строчку, а байтики =>
![image](https://github.com/wirenboard/wb-utils/assets/25829054/0f4689a7-6b1b-47ff-bff8-0447f47e4599)

результат - серийники на wb не совпадают с тем, что на наклейке