### PR TITLE
wb-gen-serial: decode imei to fix wb6x sn-generating (#131)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.12.0-wb104) stable; urgency=medium
+
+  * wb-gen-serial: decode imei to fix wb6x sn-generating
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Mon, 28 Aug 2023 12:36:12 +0300
+
 wb-utils (4.12.0-wb103) stable; urgency=medium
 
   * wb-gen-serial: look into standart Linux place

--- a/utils/bin/wb-gen-serial
+++ b/utils/bin/wb-gen-serial
@@ -128,6 +128,9 @@ def generate_serial_number():
     else:
         imei = ""
 
+    if isinstance(imei, bytes):
+        imei = imei.decode("utf-8")
+
     # read WB7 CPU serial from alternative source
     if dt_is_compatible(DT_SUNXI):
         cpuinfo_serial = str(get_wb7_cpu_serial())


### PR DESCRIPTION
нужно протащить [это](https://github.com/wirenboard/wb-utils/pull/131) в stable