### PR TITLE
wb-gen-serial: decode imei to fix wb6x sn-generating (#131)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.8.2-wb106) stable; urgency=medium
+
+  * wb-gen-serial: decode imei to fix wb6x sn-generating
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Mon, 28 Aug 2023 12:36:12 +0300
+
 wb-utils (4.8.2-wb105) stable; urgency=medium
 
   * fix FIT image install via wb-run-update with single rootfs from random

--- a/utils/bin/wb-gen-serial
+++ b/utils/bin/wb-gen-serial
@@ -127,6 +127,9 @@ def _get_serial_2():
     else:
         imei = ""
 
+    if isinstance(imei, bytes):
+        imei = imei.decode("utf-8")
+
     # read WB7 CPU serial from alternative source
     if dt_is_compatible(DT_SUNXI):
         cpuinfo_serial = str(get_wb7_cpu_serial())


### PR DESCRIPTION
нужно протащить [это](https://github.com/wirenboard/wb-utils/pull/131) в 2304, чтобы пользователи со сломанными серийниками wb6x не страдали