### PR TITLE
wb-gen-serial: decode imei to fix wb6x sn-generating (#131)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.8.1-70549e24-002) stable; urgency=medium
+
+  * wb-gen-serial: decode imei to fix wb6x sn-generating
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Mon, 28 Aug 2023 12:36:12 +0300
+
 wb-utils (4.8.1-70549e24-001) stable; urgency=medium
 
   * Backported enlarged rootfs support from wb-2304 testing

--- a/utils/bin/wb-gen-serial
+++ b/utils/bin/wb-gen-serial
@@ -127,6 +127,9 @@ def _get_serial_2():
     else:
         imei = ""
 
+    if isinstance(imei, bytes):
+        imei = imei.decode("utf-8")
+
     # read WB7 CPU serial from alternative source
     if dt_is_compatible(DT_SUNXI):
         cpuinfo_serial = str(get_wb7_cpu_serial())


### PR DESCRIPTION
наверное, и сюда нужно дать фикс серийников wb6x