### PR TITLE
fix lost loop device in 20ms-license postinst script

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.12.0-wb105-cb8ea449-1) stable; urgency=medium
+
+  * fix lost loop device in 20ms-license postinst script
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 13 Sep 2023 21:04:20 +0600
+
 wb-utils (4.12.0-wb105-cb8ea449) stable; urgency=medium
 
   * Add 20ms-license postinst script

--- a/utils/lib/wb-image-update/postinst/20ms-license
+++ b/utils/lib/wb-image-update/postinst/20ms-license
@@ -20,5 +20,6 @@ if mount "$LO_DEVICE" "$HIDDENFS_MNT" >/dev/null 2>&1; then
         echo "Failed to copy license key from hiddenfs" >&2
     }
     umount "$HIDDENFS_MNT"
+    losetup -d "$LO_DEVICE"
     sync
 fi


### PR DESCRIPTION
То, что тут loop подключается в readonly, ломает запись туда при инициализации, которая пытается выполниться уже после этого скрипта