### PR TITLE
fix fit flags

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.18.1) stable; urgency=medium
+
+  * hotfix, no functional changes
+
+ -- Aleksandr Kazadaev <aleksandr.kazadaev@wirenboard.com>  Tue, 14 Nov 2023 14:18:12 +0600
+
 wb-utils (4.18.0) stable; urgency=medium
 
   * factory reset refactoring, no functional changes

--- a/utils/lib/wb-image-update/fit/build.sh
+++ b/utils/lib/wb-image-update/fit/build.sh
@@ -85,7 +85,7 @@ cp /usr/lib/wb-image-update/fit/install_update.sh /var/lib/wb-image-update/insta
 cd "$BUILDDIR" && tar cvzf /var/lib/wb-image-update/deps.tar.gz .
 
 echo -n "+single-rootfs " > /var/lib/wb-image-update/firmware-compatible
-echo -n "+fit-factory-reset " > /var/lib/wb-image-update/firmware-compatible
+echo -n "+fit-factory-reset " >> /var/lib/wb-image-update/firmware-compatible
 echo -n "+force-repartition " >> /var/lib/wb-image-update/firmware-compatible
 
 if [[ ! -f /var/lib/wb-image-update/zImage ]] || [[ ! -f /var/lib/wb-image-update/boot.dtb ]]; then


### PR DESCRIPTION
По невнимательности пропустили `>` вместо `>>`, в результате пропадает compatibility flag `+single-rootfs` при сборке фита.