### PR TITLE
Fix root extending on 512M RAM

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.17.4ubuntu1) UNRELEASED; urgency=medium
+
+  * Remove creation of tar with tools from which install_update.sh depends on, move it to wb_initramfs 
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Wed, 08 Nov 2023 18:36:15 +0300
+
 wb-utils (4.17.4) stable; urgency=medium
 
   * install_update.sh: various mass-update features

--- a/utils/lib/wb-image-update/fit/build.sh
+++ b/utils/lib/wb-image-update/fit/build.sh
@@ -86,6 +86,7 @@ cd "$BUILDDIR" && tar cvzf /var/lib/wb-image-update/deps.tar.gz .
 
 echo -n "+single-rootfs " > /var/lib/wb-image-update/firmware-compatible
 echo -n "+force-repartition " >> /var/lib/wb-image-update/firmware-compatible
+echo -n "+repartition-ramsize-fix " >> /var/lib/wb-image-update/firmware-compatible
 
 if [[ ! -f /var/lib/wb-image-update/zImage ]] || [[ ! -f /var/lib/wb-image-update/boot.dtb ]]; then
     echo "bootlet is not found, something went wrong"

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -429,13 +429,10 @@ ensure_ab_rootfs_parttable() {
 
     cleanup_rootfs "$ROOTFS1_PART"
 
-    run_e2fsck "$ROOTFS1_PART"
-
-    # e2fsck returns 1 and 2 if some errors were fixed, it's OK for us
-    if [ "$E2FSCK_RC" -gt 2 ]; then
-        info "Filesystem check failed, can't proceed with resizing"
+    run_e2fsck "$ROOTFS1_PART" || {
+        info "Filesystem check failed, can't proceed with restoring A/B partition table"
         return 1
-    fi
+    }
 
     info "Shrinking filesystem on $ROOTFS1_PART"
     local e2fs_undofile
@@ -585,11 +582,10 @@ extend_tmpfs_size(){
     info "Extend tmpfs size to whole RAM"
     MEMSIZE_KB=`cat /proc/meminfo | grep MemTotal | awk '{print $2}'`
     MEMSIZE_MB=$((MEMSIZE_KB / 1024))
-    NEW_MEMSIZE_MB=$((MEMSIZE_MB - 200))
 
 
-    info "Remount tmpfs in /tmp with size=${NEW_MEMSIZE_MB}M"
-    mount -o remount,size=${NEW_MEMSIZE_MB}M /tmp
+    info "Remount tmpfs in /tmp with size=${MEMSIZE_MB}M"
+    mount -o remount,size=${MEMSIZE_MB}M /tmp
 }
 
 maybe_update_current_factory_tmpfs_size_fix(){

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -585,9 +585,11 @@ extend_tmpfs_size(){
     info "Extend tmpfs size to whole RAM"
     MEMSIZE_KB=`cat /proc/meminfo | grep MemTotal | awk '{print $2}'`
     MEMSIZE_MB=$((MEMSIZE_KB / 1024))
+    NEW_MEMSIZE_MB=$((MEMSIZE_MB - 200))
 
-    info "Remount tmpfs in /tmp with size=${MEMSIZE_MB}M"
-    mount -o remount,size=${MEMSIZE_MB}M /tmp
+
+    info "Remount tmpfs in /tmp with size=${NEW_MEMSIZE_MB}M"
+    mount -o remount,size=${NEW_MEMSIZE_MB}M /tmp
 }
 
 maybe_update_current_factory_tmpfs_size_fix(){

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -583,9 +583,13 @@ extend_tmpfs_size(){
     MEMSIZE_KB=`cat /proc/meminfo | grep MemTotal | awk '{print $2}'`
     MEMSIZE_MB=$((MEMSIZE_KB / 1024))
 
-
     info "Remount tmpfs in /tmp with size=${MEMSIZE_MB}M"
     mount -o remount,size=${MEMSIZE_MB}M /tmp
+
+    info "Creating swap"
+
+    local swap=${ROOTDEV}p5
+    swapon ${swap} || true
 }
 
 maybe_update_current_factory_tmpfs_size_fix(){

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -1058,7 +1058,6 @@ if ! flag_set from-initramfs && flag_set "force-repartition"; then
 fi
 
 if ( ( flag_set "factoryreset" || flag_set "force-repartition" ) && ! flag_set "no-repartition" ); then
-    maybe_fix_tmpfs_size
     maybe_repartition
 fi
 

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -588,9 +588,16 @@ maybe_fix_tmpfs_size(){
     MEMSIZE_MB=$((MEMSIZE_KB / 1024))
 
     if ((MEMSIZE_MB>=490 && MEMSIZE_MB<=512)); then
+        CURRENT_SIZE=`df -h | grep tmpfs | awk '{print $2}' | head -n1 | head -c -2`
         NEW_SIZE=$((MEMSIZE_MB-200))
-        info "512M RAM size detected, remount tmpfs in /tmp with size=${NEW_SIZE}M"
-        mount -o remount,size=${NEW_SIZE}M /tmp
+
+        info "$CURRENT_SIZE"
+        info "$NEW_SIZE"
+
+        if ! [ $CURRENT_SIZE -eq $NEW_SIZE ]; then
+            info "512M RAM size detected, remount tmpfs in /tmp with size=${NEW_SIZE}M"
+            mount -o remount,size=${NEW_SIZE}M /tmp
+        fi
 
         local mnt
         mnt=$(mktemp -d)

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -605,7 +605,7 @@ maybe_update_current_factory_tmpfs_size_fix(){
             info "Replace factoryreset.fit with current fit to fix rootfs extending issue at 512M RAM" 
             cp "$FIT" "$mnt/.wb-restore/factoryreset.fit"
         else
-            info "Factoryreset.fit has a 512M RAM repartition fix already (repartition-ramsize-fix comatibility)"
+            info "Factoryreset.fit already includes a fix for the 512MB RAM repartition issue (repartition-ramsize-fix compatibility)"
         fi
 
         umount "$mnt" || true

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -588,11 +588,6 @@ extend_tmpfs_size(){
 
     info "Remount tmpfs in /tmp with size=${MEMSIZE_MB}M"
     mount -o remount,size=${MEMSIZE_MB}M /tmp
-
-    info "Creating swap"
-
-    local swap=${ROOTDEV}p5
-    swapon ${swap} || true
 }
 
 maybe_update_current_factory_tmpfs_size_fix(){

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -589,19 +589,10 @@ extend_tmpfs_size(){
     info "Remount tmpfs in /tmp with size=${MEMSIZE_MB}M"
     mount -o remount,size=${MEMSIZE_MB}M /tmp
 
-    info "Try to attach swap"
+    info "Creating swap"
 
     local swap=${ROOTDEV}p5
-    grep ${swap} /proc/swaps 2>&1 >/dev/null && return 0
-
-    [[ -e "${swap}" ]] || {
-        log_failure_msg "Swap device $swap not found"
-        return 1
-    }
-
-    info "Creating swap"
-    mkswap ${ROOTDEV}p5 &&
-    swapon -a
+    swapon ${swap} || true
 }
 
 maybe_update_current_factory_tmpfs_size_fix(){
@@ -622,13 +613,11 @@ maybe_update_current_factory_tmpfs_size_fix(){
             info "Replace factoryreset.fit with current fit to fix rootfs extending issue at 512M RAM" 
             cp "$FIT" "$mnt/.wb-restore/factoryreset.fit"
         else
-            info "Factoryreset.fit has a fix already"
+            info "Factoryreset.fit has a 512M RAM repartition fix already (repartition-ramsize-fix comatibility)"
         fi
 
         umount "$mnt" || true
         sync
-    else
-        info "Amount of RAM bigger than 1G, do not update factoryreset.fit" 
     fi
 }
 

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -585,11 +585,6 @@ extend_tmpfs_size(){
 
     info "Remount tmpfs in /tmp with size=${MEMSIZE_MB}M"
     mount -o remount,size=${MEMSIZE_MB}M /tmp
-
-    info "Creating swap"
-
-    local swap=${ROOTDEV}p5
-    swapon ${swap} || true
 }
 
 maybe_update_current_factory_tmpfs_size_fix(){

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -588,6 +588,20 @@ extend_tmpfs_size(){
 
     info "Remount tmpfs in /tmp with size=${MEMSIZE_MB}M"
     mount -o remount,size=${MEMSIZE_MB}M /tmp
+
+    info "Try to attach swap"
+
+    local swap=${ROOTDEV}p5
+    grep ${swap} /proc/swaps 2>&1 >/dev/null && return 0
+
+    [[ -e "${swap}" ]] || {
+        log_failure_msg "Swap device $swap not found"
+        return 1
+    }
+
+    info "Creating swap"
+    mkswap ${ROOTDEV}p5 &&
+    swapon -a
 }
 
 maybe_update_current_factory_tmpfs_size_fix(){

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -580,7 +580,7 @@ select_new_partition() {
 
 extend_tmpfs_size(){
     info "Extend tmpfs size to whole RAM"
-    MEMSIZE_KB=`cat /proc/meminfo | grep MemTotal | awk '{print $2}'`
+    MEMSIZE_KB=$(grep MemTotal /proc/meminfo | awk '{print $2}')
     MEMSIZE_MB=$((MEMSIZE_KB / 1024))
 
     info "Remount tmpfs in /tmp with size=${MEMSIZE_MB}M"
@@ -590,7 +590,7 @@ extend_tmpfs_size(){
 maybe_update_current_factory_tmpfs_size_fix(){
     info "Maybe update factoryreset.fit to fix tmpfs size issue at 512M RAM (with emmc update)"
 
-    MEMSIZE_KB=`cat /proc/meminfo | grep MemTotal | awk '{print $2}'`
+    MEMSIZE_KB=$(grep MemTotal /proc/meminfo | awk '{print $2}')
     MEMSIZE_MB=$((MEMSIZE_KB / 1024))
 
     if ((MEMSIZE_MB<1024)); then


### PR DESCRIPTION
Из за бага не хватало размера tmpfs, сделала расчет такой же как в свежей версии initramfs. Чтобы можно было делать фектори ресет из файла, сделала замену factoryreset.fit, так как после расширения рутфс откатиться назад мешала та же причина с маленьким размером tmpfs