### PR TITLE
fix upgrade from wb-2304 release, no functional changes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.20.2) stable; urgency=medium
+
+  * fix upgrade from wb-2304 release, no functional changes
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 06 Dec 2023 15:34:26 +0600
+
 wb-utils (4.20.1) stable; urgency=medium
 
   * More fixes for factoryreset support, no functional changes

--- a/debian/control
+++ b/debian/control
@@ -10,8 +10,7 @@ Package: wb-utils
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, lsb-base (>= 4.1), u-boot-tools-wb (>= 2015.07+wb-3), inotify-tools, pv, jq,
          nginx-extras, python3-wb-common (>= 2.0.0~~), wb-configs (>= 3.18.0~~), util-linux,
-         linux-image-wb6 (>= 5.10.35-wb108~~) | linux-image-wb7 (>= 5.10.35-wb130~~),
-         wb-bootlet-wb6x | wb-bootlet-wb7x,
+         linux-image-wb6 (>= 5.10.35-wb108~~) | linux-image-wb7 (>= 5.10.35-wb130~~), wb-bootlet,
          device-tree-compiler, parted, rsync, systemd (>= 243), wb-ec-firmware
 Conflicts: wb-configs (<< 1.69.4)
 Breaks: wb-homa-ism-radio (<< 1.17.2), wb-rules-system (<< 1.6.1), wb-mqtt-serial (<< 1.47.2), wb-mqtt-homeui (<< 1.7.1),


### PR DESCRIPTION
Проблема оказалась в следующем. В релизе wb-2304 ещё не было пакетов `wb-bootlet-wb6x|7x`, они должны были заехать через зависимость в wb-utils. При установке они конфликтуют и выбирается только один из них (внутри каждого из них прописана зависимость от соответствующего ядра, чтобы не путать платформу).

При переходе с 2304 на testing apt почему-то решал, что установить бутлет от wb6 на wb7 - хорошая идея. Внутри stable (например, при переходе с 2304 на 2310) проблема не воспроизводилась, потому что в stable-репозиториях нет чужих ядер и бутлетов.

Если заменить зависимость от двух разных бутлетов на зависимость от виртуального пакета, который прописан во всех бутлетах, apt разбирается чуть лучше. Вероятно, если перечислять пакеты через `|`, apt считает первый в списке более приоритетным.

Проверил процедуру обновления на wb6 и wb7.