### PR TITLE
Add modem watchdog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ install: build_mass_storage
 		utils/bin/wb-gen-serial \
 		utils/bin/wb-set-mac \
 		utils/bin/wb-gsm \
+		utils/bin/wb-gsm-mm \
 		utils/bin/wb-factoryreset \
 		utils/bin/wb-watch-update \
 		utils/bin/wb-run-update

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.20.3) stable; urgency=medium
+
+  * Add modem watchdog
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 30 Jan 2024 15:44:12 +0500
+
 wb-utils (4.20.2) stable; urgency=medium
 
   * fix upgrade from wb-2304 release, no functional changes

--- a/debian/wb-utils.wb-gsm.service
+++ b/debian/wb-utils.wb-gsm.service
@@ -5,11 +5,12 @@ Before=network-pre.target
 After=wb-hwconf-manager.service
 
 [Service]
-Type=oneshot
-ExecStart=wb-gsm mm_on
+Type=simple
+ExecStart=wb-gsm-mm
 ExecStop=wb-gsm mm_off
 ExecCondition=wb-gsm should_enable
-RemainAfterExit=yes
+Restart=on-failure
+WatchdogSec=300
 
 [Install]
 WantedBy=multi-user.target

--- a/utils/bin/wb-gsm-mm
+++ b/utils/bin/wb-gsm-mm
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+watchdog() {
+    while(true); do
+        if lsusb | grep -q "1e0e:9011"; then
+            systemd-notify WATCHDOG=1;
+        fi
+        sleep $(($WATCHDOG_USEC / 3000000))
+    done
+}
+
+wb-gsm mm_off
+wb-gsm mm_on
+watchdog

--- a/utils/bin/wb-gsm-mm
+++ b/utils/bin/wb-gsm-mm
@@ -3,7 +3,7 @@
 watchdog() {
     while true; do
         if lsusb | grep -q "1e0e:9011"; then
-            systemd-notify WATCHDOG=1;
+            systemd-notify WATCHDOG=1
         fi
         sleep $(($WATCHDOG_USEC / 3000000))
     done

--- a/utils/bin/wb-gsm-mm
+++ b/utils/bin/wb-gsm-mm
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 watchdog() {
-    while(true); do
+    while true; do
         if lsusb | grep -q "1e0e:9011"; then
             systemd-notify WATCHDOG=1;
         fi


### PR DESCRIPTION
Простой watchdog для модема. Если в течение 5 минут нет USB устройства модема, то перезапускаем его по питанию