### PR TITLE
Feature/wb gsm 68

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.22.1) stable; urgency=medium
+
+  * wb-gsm: fix modem turning-on & simselect on 6.8 kernel
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Thu, 27 Jun 2024 18:02:17 +0300
+
 wb-utils (4.22.0) stable; urgency=medium
 
   * wb-watch-update: add is-update-from-cloud check ("+update-from-cloud" flag)

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, lsb-base (>= 4.1), u-boot-tools-wb (>= 2015.07+wb-3), inotify-tools, pv, jq,
          nginx-extras, python3-wb-common (>= 2.0.0~~), wb-configs (>= 3.18.0~~), util-linux,
          linux-image-wb6 (>= 5.10.35-wb108~~) | linux-image-wb7 (>= 5.10.35-wb130~~) | linux-image-wb8, wb-bootlet,
-         device-tree-compiler, parted, rsync, systemd (>= 243), wb-ec-firmware
+         device-tree-compiler, parted, rsync, gpiod, systemd (>= 243), wb-ec-firmware
 Conflicts: wb-configs (<< 1.69.4)
 Breaks: wb-homa-ism-radio (<< 1.17.2), wb-rules-system (<< 1.6.1), wb-mqtt-serial (<< 1.47.2), wb-mqtt-homeui (<< 1.7.1),
         u-boot-wb7 (<< 2:2021.10+wb1.5.0~~), u-boot-wb6 (<< 2:2021.10+wb1.6.0~~)

--- a/utils/lib/wb-gsm-common.sh
+++ b/utils/lib/wb-gsm-common.sh
@@ -10,6 +10,7 @@ USB_SYMLINK_MASK="/dev/ttyGSM"
 
 OF_GSM_NODE="wirenboard/gsm"  # deprecated since default modem's connection is usb
 
+GPIOD_GET_CMD="gpioget"
 
 function guess_of_node() {
     # default modem's connection is usb (with modem node on specific port)
@@ -366,11 +367,9 @@ function gsm_init() {
     fi
 
     if [[ -n $gpio_gsm_status ]]; then
-        gpio_setup $gpio_gsm_status in
+        # gpio_setup $gpio_gsm_status in
         if of_gpio_is_inverted $(of_prop_required of_get_prop_gpio $OF_GSM_NODE "status-gpios"); then
-            gpio_set_inverted $gpio_gsm_status 1
-        else
-            gpio_set_inverted $gpio_gsm_status 0
+            GPIOD_GET_CMD="gpioget -l"
         fi
     fi
 
@@ -388,7 +387,7 @@ function gsm_init() {
     handle_mm
 
     if has_usb; then
-        if [[ `gpio_get_value $gpio_gsm_status` -eq "1" ]]; then
+        if [[ `$GPIOD_GET_CMD $(gpiofind "GSM STATUS")` -eq "1" ]]; then
             debug "USB modem is turned on already; probing ($PORT, ${USB_SYMLINK_MASK}*) ports"
             for port in $PORT ${USB_SYMLINK_MASK}[0-9]*; do
                 [[ -c $port ]] && [[ $(test_connection $port 2) == 0 ]] && {
@@ -530,7 +529,7 @@ function switch_off() {
 
     handle_mm
 
-    [[ -n $gpio_gsm_status ]] && [[ "`gpio_get_value $gpio_gsm_status`" = "0" ]] && {
+    [[ -n $gpio_gsm_status ]] && [[ `$GPIOD_GET_CMD $(gpiofind "GSM STATUS")` = "0" ]] && {
         debug "Modem is already OFF"
         return 0
     } || debug "Modem is ON. Will try to switch off GSM modem "
@@ -551,7 +550,7 @@ function switch_off() {
         max_tries=25
 
         for ((i=0; i<=upperlim; i++)); do
-            if [[ "`gpio_get_value $gpio_gsm_status`" = "0" ]]; then
+            if [[ `$GPIOD_GET_CMD $(gpiofind "GSM STATUS")` = "0" ]]; then
                 break
             fi
             sleep 0.2
@@ -574,7 +573,7 @@ function ensure_on() {
     local gpio_gsm_power=$(of_prop_required of_get_prop_gpionum $OF_GSM_NODE "power-gpios")
 
     if [[ -n "$gpio_gsm_status" ]]; then
-        if [[ "`gpio_get_value $gpio_gsm_status`" = "1" ]]; then
+        if [[ `$GPIOD_GET_CMD $(gpiofind "GSM STATUS")` = "1" ]]; then
             debug "Modem is already switched on"
             return
         fi
@@ -594,7 +593,7 @@ function ensure_on() {
         max_tries=30
 
         for ((i=0; i<=max_tries; i++)); do
-            if [[ "`gpio_get_value $gpio_gsm_status`" = "1" ]]; then
+            if [[ `$GPIOD_GET_CMD $(gpiofind "GSM STATUS")` = "1" ]]; then
                 break
             fi
             sleep 0.1
@@ -627,7 +626,7 @@ function restart_if_broken() {
     #~ set_speed
     local RC=0
     if [[ -n "$gpio_gsm_status" ]]; then
-        if [[ "`gpio_get_value $gpio_gsm_status`" = "0" ]]; then
+        if [[ `$GPIOD_GET_CMD $(gpiofind "GSM STATUS")` = "0" ]]; then
             debug "Modem switched off, switch it on instead of testing the connection"
             local RC=1
         fi
@@ -726,12 +725,10 @@ function mm_gsm_init() {
 
     gpio_setup $gpio_gsm_pwrkey out
     gpio_setup $gpio_gsm_power out
-    gpio_setup $gpio_gsm_status in
+    # gpio_setup $gpio_gsm_status in
 
     if of_gpio_is_inverted $(of_prop_required of_get_prop_gpio $OF_GSM_NODE "status-gpios"); then
-        gpio_set_inverted $gpio_gsm_status 1
-    else
-        gpio_set_inverted $gpio_gsm_status 0
+        GPIOD_GET_CMD="gpioget -l"
     fi
 }
 
@@ -743,7 +740,7 @@ function mm_on() {
     local gpio_gsm_power=$(of_prop_required of_get_prop_gpionum $OF_GSM_NODE "power-gpios")
     local gpio_gsm_pwrkey=$(of_prop_required of_get_prop_gpionum $OF_GSM_NODE "pwrkey-gpios")
 
-    if [[ "`gpio_get_value $gpio_gsm_status`" = "1" ]]; then
+    if [[ `$GPIOD_GET_CMD $(gpiofind "GSM STATUS")` = "1" ]]; then
         debug "Modem is already switched on"
         return 0
     fi
@@ -760,7 +757,7 @@ function mm_on() {
     debug "Waiting for modem to start"
     max_tries=40
     for ((i=0; i<=max_tries; i++)); do
-        if [[ "`gpio_get_value $gpio_gsm_status`" = "1" ]]; then
+        if [[ `$GPIOD_GET_CMD $(gpiofind "GSM STATUS")` = "1" ]]; then
             break
         fi
         sleep 0.5
@@ -775,7 +772,7 @@ function mm_off() {
     local gpio_gsm_power=$(of_prop_required of_get_prop_gpionum $OF_GSM_NODE "power-gpios")
     local gpio_gsm_pwrkey=$(of_prop_required of_get_prop_gpionum $OF_GSM_NODE "pwrkey-gpios")
 
-    if [[ "`gpio_get_value $gpio_gsm_status`" = "0" ]]; then
+    if [[ `$GPIOD_GET_CMD $(gpiofind "GSM STATUS")` = "0" ]]; then
         debug "Modem is already OFF"
         return 0
     else
@@ -792,7 +789,7 @@ function mm_off() {
     debug "Waiting for modem to stop"
     max_tries=25
     for ((i=0; i<=max_tries; i++)); do
-        if [[ "`gpio_get_value $gpio_gsm_status`" = "0" ]]; then
+        if [[ `$GPIOD_GET_CMD $(gpiofind "GSM STATUS")` = "0" ]]; then
             debug "Modem is OFF"
             break
         fi

--- a/utils/lib/wb-gsm-common.sh
+++ b/utils/lib/wb-gsm-common.sh
@@ -367,7 +367,7 @@ function gsm_init() {
     fi
 
     if [[ -n $gpio_gsm_status ]]; then
-        # gpio_setup $gpio_gsm_status in
+        gpio_unexport $gpio_gsm_status || true  # release for gpiod
         if of_gpio_is_inverted $(of_prop_required of_get_prop_gpio $OF_GSM_NODE "status-gpios"); then
             GPIOD_GET_CMD="gpioget -l"
         fi
@@ -725,7 +725,7 @@ function mm_gsm_init() {
 
     gpio_setup $gpio_gsm_pwrkey out
     gpio_setup $gpio_gsm_power out
-    # gpio_setup $gpio_gsm_status in
+    gpio_unexport $gpio_gsm_status || true  # release for gpiod
 
     if of_gpio_is_inverted $(of_prop_required of_get_prop_gpio $OF_GSM_NODE "status-gpios"); then
         GPIOD_GET_CMD="gpioget -l"

--- a/utils/lib/wb-gsm-common.sh
+++ b/utils/lib/wb-gsm-common.sh
@@ -739,11 +739,17 @@ function mm_on() {
     local gpio_gsm_status=$(of_prop_required of_get_prop_gpionum $OF_GSM_NODE "status-gpios")
     local gpio_gsm_power=$(of_prop_required of_get_prop_gpionum $OF_GSM_NODE "power-gpios")
     local gpio_gsm_pwrkey=$(of_prop_required of_get_prop_gpionum $OF_GSM_NODE "pwrkey-gpios")
+    local gpio_gsm_simselect=$(of_prop_required of_get_prop_gpionum $OF_GSM_NODE "simselect-gpios")
 
     if [[ `$GPIOD_GET_CMD $(gpiofind "GSM STATUS")` = "1" ]]; then
         debug "Modem is already switched on"
         return 0
     fi
+
+    # MM assumes simselect to be output and released
+    gpio_setup $gpio_gsm_simselect out
+    gpio_set_value $gpio_gsm_simselect 0  # sim1
+    gpio_unexport $gpio_gsm_simselect
 
     gpio_set_value $gpio_gsm_power 1
     sleep 1


### PR DESCRIPTION
с переходом на ядро 6.8, с модемом возникли проблемки:

первый коммит - состояние gsm-status не видно (никак не меняется) через sysfs; рисёчил-коротил на землю => дело где-то в наших hardware-хелперах; решение - смотрим в него через gpiod
![image](https://github.com/wirenboard/wb-utils/assets/25829054/433134c0-5ab2-48a4-9408-659af3e03dba)


остальные коммиты - в связке с MM что-то не работал simselect; мы с @KraPete порисёчили - MM хочет, чтобы simselect был output-ом

на wb7 я еще не проверял, но смотреть уже можно