### PR TITLE
introduce wb-fix-hardware.service: reconfigures hardware-specific

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,8 @@ install: build_mass_storage
 		utils/lib/prepare/vars.sh
 
 	install -Dm0755 -t $(PREPARE_LIBDIR) \
-		utils/lib/prepare/wb-prepare.sh
+		utils/lib/prepare/wb-prepare.sh \
+		utils/lib/prepare/wb-fix-hardware.sh
 
 	install -Dm0755 -t $(BINDIR) \
 		utils/bin/wb-gen-serial \

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wb-utils (4.23.0) stable; urgency=medium
+
+  * introduce wb-fix-hardware.service:
+    reconfigures hw-dependent services at firstboot
+    to acquire correct configs, dependent on actually loaded dts
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Tue, 06 Aug 2024 12:11:09 +0300
+
 wb-utils (4.22.2) stable; urgency=medium
 
   * wb-usb-otg: is supported on all wirenboard-8xx compatible devices

--- a/debian/rules
+++ b/debian/rules
@@ -5,6 +5,7 @@
 override_dh_installsystemd:
 	dh_installsystemd --name=wb-prepare --no-start --no-restart-after-upgrade --no-restart-on-upgrade
 	dh_installsystemd --name=wb-init --no-start --no-restart-after-upgrade --no-restart-on-upgrade
+	dh_installsystemd --name=wb-fix-hardware --no-start --no-restart-after-upgrade --no-restart-on-upgrade
 	dh_installsystemd --name=wb-watch-update
 	dh_installsystemd --name=wb-gsm
 	dh_installsystemd --name=wb-usb-otg
@@ -12,6 +13,7 @@ override_dh_installsystemd:
 override_dh_systemd_enable:
 	dh_systemd_enable --name=wb-prepare wb-prepare.service
 	dh_systemd_enable --name=wb-init wb-init.service
+	dh_systemd_enable --name=wb-fix-hardware wb-fix-hardware.service
 	dh_systemd_enable --name=wb-watch-update wb-watch-update.service
 	dh_systemd_enable --name=wb-gsm wb-gsm.service
 	dh_systemd_enable --name=wb-usb-otg wb-usb-otg.service
@@ -19,6 +21,7 @@ override_dh_systemd_enable:
 override_dh_systemd_start:
 	dh_systemd_start --name=wb-prepare --no-start wb-prepare.service
 	dh_systemd_start --name=wb-init --no-start wb-init.service
+	dh_systemd_start --name=wb-fix-hardware --no-start wb-fix-hardware.service
 	dh_systemd_start --name=wb-watch-update --restart-after-upgrade wb-watch-update.service
 	dh_systemd_start --name=wb-gsm wb-gsm.service
 	dh_systemd_start --name=wb-usb-otg wb-usb-otg.service

--- a/debian/wb-utils.wb-fix-hardware.service
+++ b/debian/wb-utils.wb-fix-hardware.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=fix hardware-dependent services configs at first boot (with actual dts loaded)
+Conflicts=shutdown.target
+After=first-boot-complete.target wb-init.service wb-configs.service
+Wants=first-boot-complete.target
+RefuseManualStop=true
+ConditionFirstBoot=yes
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/lib/wb-utils/prepare/wb-fix-hardware.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/wb-utils.wb-fix-hardware.service
+++ b/debian/wb-utils.wb-fix-hardware.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=fix hardware-dependent services configs at first boot (with actual dts loaded)
 Conflicts=shutdown.target
-After=first-boot-complete.target wb-init.service wb-configs.service
+After=first-boot-complete.target wb-init.service wb-configs.service watchdog.service
 Wants=first-boot-complete.target
 RefuseManualStop=true
 ConditionFirstBoot=yes

--- a/utils/lib/prepare/wb-fix-hardware.sh
+++ b/utils/lib/prepare/wb-fix-hardware.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+dpkg-reconfigure wb-configs


### PR DESCRIPTION
services at firstboot

связано с выпуском WB85: концептуально мы решили иметь один fit на 8x и 85x => рутфс собирается (и кладёт конфиги) на основе какой-то dts (в нашем случае - общей 8x-85x)

=> основные сервисы умеют собирать свой hw-dependent конфиг в рантайме на основе compatible, с которым мы загрузились; но вот оказалось, что кое-где подкладывание правильного конфига осталось при установке пакета