### PR TITLE
wb-prepare: run scripts from /etc/wb-prepare.d on firstboot

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.23.0) stable; urgency=medium
+
+  * wb-prepare: run scripts from /etc/wb-prepare.d on firstboot
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Fri, 09 Aug 2024 17:53:39 +0300
+
 wb-utils (4.22.2) stable; urgency=medium
 
   * wb-usb-otg: is supported on all wirenboard-8xx compatible devices

--- a/utils/lib/prepare/wb-prepare.sh
+++ b/utils/lib/prepare/wb-prepare.sh
@@ -265,6 +265,14 @@ wb_fix_machine_id()
     systemd-machine-id-setup
 }
 
+wb_run_scripts()
+{
+    local scriptsdir=$1
+    if [[ -d $scriptsdir ]]; then
+        run-parts -v $scriptsdir
+    fi
+}
+
 # This function should be called only on first boot of the rootfs
 wb_firstboot()
 {
@@ -309,6 +317,8 @@ wb_firstboot()
     done
 
     sync
+
+    wb_run_scripts /etc/wb-prepare.d
 
     if $FIRSTBOOT_NEED_REBOOT; then
         reboot


### PR DESCRIPTION
Для wb85 в wb-configs нужно подсовывать udev-правила в уже загрузившейся системе с нормальным dts.
Посовещавшись, для этого решили внедрить wb-prepare.d механизм