### PR TITLE
Feature/protect factory fit

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.24.0) stable; urgency=medium
+
+  * support immutable factory-fit
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Tue, 24 Sep 2024 10:56:21 +0300
+
 wb-utils (4.23.0) stable; urgency=medium
 
   * wb-prepare: run scripts from /etc/wb-prepare.d on firstboot

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: https://github.com/wirenboard/wb-utils
 Package: wb-utils
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, lsb-base (>= 4.1), u-boot-tools-wb (>= 2015.07+wb-3), inotify-tools, pv, jq,
-         nginx-extras, python3-wb-common (>= 2.0.0~~), wb-configs (>= 3.18.0~~), util-linux,
+         nginx-extras, python3-wb-common (>= 2.0.0~~), wb-configs (>= 3.31.0~~), util-linux,
          linux-image-wb6 (>= 5.10.35-wb108~~) | linux-image-wb7 (>= 5.10.35-wb130~~) | linux-image-wb8, wb-bootlet,
          device-tree-compiler, parted, rsync, gpiod, systemd (>= 243), wb-ec-firmware
 Conflicts: wb-configs (<< 1.69.4)

--- a/utils/bin/wb-factoryreset
+++ b/utils/bin/wb-factoryreset
@@ -45,7 +45,6 @@ if [[ "$1" != "--force" ]]; then
 fi
 
 mkdir -p "$DIR_UPDATE"
-echo "--factoryreset --from-emmc-factoryreset " > "$DIR_UPDATE/install_update.web.flags"
 touch "$DIR_UPDATE/wb_use_factory_fit.flag"  # to trigger wb-watch-update
 
 echo "Factory reset initiated, system will reboot soon"

--- a/utils/bin/wb-factoryreset
+++ b/utils/bin/wb-factoryreset
@@ -46,8 +46,7 @@ fi
 
 mkdir -p "$DIR_UPDATE"
 echo "--factoryreset --from-emmc-factoryreset " > "$DIR_UPDATE/install_update.web.flags"
-ln "$DIR_RESTORE/factoryreset.fit" "$DIR_UPDATE/webupd.fit"
-touch "$DIR_UPDATE/webupd.fit"  # to trigger wb-watch-update
+touch "$DIR_UPDATE/wb_use_factory_fit.flag"  # to trigger wb-watch-update
 
 echo "Factory reset initiated, system will reboot soon"
 

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -26,6 +26,7 @@ flag_set() {
 rm_fit() {
 	flag_set no-remove && return 0
 	info "Removing FIT $FIT"
+	chattr -i "$FIT"
 	rm -f "$FIT"
 }
 

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -17,6 +17,8 @@ FLAGS=""
 # for factory reset
 DATA_PART="/dev/mmcblk0p6"
 DATA_LABEL="data"
+FACTORY_FIT_DIR="/mnt/data/.wb-restore"
+FACTORY_FIT="${FACTORY_FIT_DIR}/factoryreset.fit"
 
 # Some handy functions, usable in install script
 flag_set() {
@@ -26,8 +28,16 @@ flag_set() {
 rm_fit() {
 	flag_set no-remove && return 0
 	info "Removing FIT $FIT"
-	chattr -i "$FIT"
-	rm -f "$FIT"
+	if [ "$FIT" -ef "$FACTORY_FIT" ]; then
+		info "$FIT is a hardlink to factory-fit; saving factory-fit immutability"
+		was_immutable=$(lsattr -l $FACTORY_FIT | grep "Immutable" || true)
+		chattr -i $FIT
+		rm -f "$FIT"
+		sync
+		[[ -n "$was_immutable" ]] && chattr +i $FACTORY_FIT
+	else
+		rm -f "$FIT"
+	fi
 }
 
 led() {
@@ -310,8 +320,6 @@ if flag_set factoryreset; then
             rm -rf /tmp/empty && mkdir /tmp/empty
             rsync -a --delete --exclude="/.wb-restore/" /tmp/empty/ /mnt/data/
 
-            FACTORY_FIT_DIR="/mnt/data/.wb-restore"
-            FACTORY_FIT="${FACTORY_FIT_DIR}/factoryreset.fit"
             if [[ ! -e "$FACTORY_FIT" ]]; then
                 echo "Saving current update file as factory default image"
                 mkdir -p "${FACTORY_FIT_DIR}"

--- a/utils/bin/wb-watch-update
+++ b/utils/bin/wb-watch-update
@@ -173,6 +173,7 @@ while read EVENT_DIR EVENT_TYPE EVENT_FILE; do
     # Ensure that image was received completely
     check_fully_received $FIT || {
         if [[ $EVENT_FILE == "wb_use_factory_fit.flag" ]]; then
+            log "received wb_use_factory_fit.flag; hardlinking factory-fit to webupd file"
             echo "--factoryreset --from-emmc-factoryreset " > "${EVENT_DIR}install_update.web.flags"
             webupd_fit_file="webupd.fit"
             FIT="${EVENT_DIR}${webupd_fit_file}"

--- a/utils/bin/wb-watch-update
+++ b/utils/bin/wb-watch-update
@@ -9,6 +9,8 @@ PID_FILE="/var/run/wb-watch-update.pid"
 AB_WATCH_DIR="/var/www/uploads"
 SINGLE_WATCH_DIR="/mnt/data/.wb-update"
 
+WB_FACTORY_FIT="/mnt/data/.wb-restore/factoryreset.fit"
+
 # added to read FIT compatibility flags
 fit_prop() {
     local node=$1
@@ -121,22 +123,13 @@ publish_fit_info() {
 }
 
 publish_factoryreset_fits_info() {
-    local factoryreset_fit="/mnt/data/.wb-restore/factoryreset.fit"
     local factoryreset_original_fit="/mnt/data/.wb-restore/factoryreset.original.fit"
 
-    publish_fit_info "$factoryreset_fit" "factoryreset"
+    publish_fit_info "$WB_FACTORY_FIT" "factoryreset"
     publish_fit_info "$factoryreset_original_fit" "factoryreset-original"
 }
 
-make_factoryreset_fit_accessible() {
-    if [ -f /mnt/data/.wb-restore/factoryreset.fit ]; then
-        chown root:www-data /mnt/data/.wb-restore/factoryreset.fit
-        chmod 0660 /mnt/data/.wb-restore/factoryreset.fit
-    fi
-}
-
-# Web FR needs rw access to factory fit to create hardlink and open it for writing to trigger wb-watch-update
-make_factoryreset_fit_accessible
+chattr +i $WB_FACTORY_FIT
 
 publish_factoryreset_fits_info
 
@@ -181,13 +174,24 @@ while read EVENT_DIR EVENT_TYPE EVENT_FILE; do
 
     # Ensure that image was received completely
     check_fully_received $FIT || {
-        msg="Received incomplete update FIT $FIT, don't starting update"
-        log "$msg"
-        mqtt_status "ERROR $msg"
-        mqtt_status "IDLE"
-        rm -f $FIT
-        LAST_FIT=""
-        continue
+        if [[ $EVENT_FILE == "wb_use_factory_fit.flag" ]]; then
+            echo "--factoryreset --from-emmc-factoryreset " > "${EVENT_DIR}install_update.web.flags"
+            webupd_fit_file="webupd.fit"
+            FIT="${EVENT_DIR}${webupd_fit_file}"
+            EVENT_FILE="$webupd_fit_file"
+            chattr -i $WB_FACTORY_FIT
+            ln "$WB_FACTORY_FIT" "$FIT"  # uboot has hardcoded webupd fit name
+            sync
+            chattr +i $WB_FACTORY_FIT
+        else
+            msg="Received incomplete update FIT $FIT, don't starting update"
+            log "$msg"
+            mqtt_status "ERROR $msg"
+            mqtt_status "IDLE"
+            rm -f $FIT
+            LAST_FIT=""
+            continue
+        fi
     }
 
     # Remove old updates, we won't run it anyway

--- a/utils/bin/wb-watch-update
+++ b/utils/bin/wb-watch-update
@@ -129,8 +129,6 @@ publish_factoryreset_fits_info() {
     publish_fit_info "$factoryreset_original_fit" "factoryreset-original"
 }
 
-chattr +i $WB_FACTORY_FIT
-
 publish_factoryreset_fits_info
 
 maybe_publish_singlemode_update_status
@@ -179,10 +177,11 @@ while read EVENT_DIR EVENT_TYPE EVENT_FILE; do
             webupd_fit_file="webupd.fit"
             FIT="${EVENT_DIR}${webupd_fit_file}"
             EVENT_FILE="$webupd_fit_file"
+            was_immutable=$(lsattr -l $WB_FACTORY_FIT | grep "Immutable" || true)
             chattr -i $WB_FACTORY_FIT
             ln "$WB_FACTORY_FIT" "$FIT"  # uboot has hardcoded webupd fit name
             sync
-            chattr +i $WB_FACTORY_FIT
+            [[ -n "$was_immutable" ]] && chattr +i $WB_FACTORY_FIT
         else
             msg="Received incomplete update FIT $FIT, don't starting update"
             log "$msg"

--- a/utils/lib/wb-image-update/fit/build.sh
+++ b/utils/lib/wb-image-update/fit/build.sh
@@ -88,6 +88,7 @@ echo -n "+single-rootfs " > /var/lib/wb-image-update/firmware-compatible
 echo -n "+fit-factory-reset " >> /var/lib/wb-image-update/firmware-compatible
 echo -n "+force-repartition " >> /var/lib/wb-image-update/firmware-compatible
 echo -n "+repartition-ramsize-fix " >> /var/lib/wb-image-update/firmware-compatible
+echo -n "+fit-immutable-support " >> /var/lib/wb-image-update/firmware-compatible
 
 if of_machine_match "wirenboard,wirenboard-8xx"; then
     KERNEL_IMAGE="Image.gz"

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -603,7 +603,9 @@ maybe_update_current_factory_tmpfs_size_fix(){
 
         if ! FIT="$CURRENT_FACTORY_FIT" fw_compatible repartition-ramsize-fix; then
             info "Replace factoryreset.fit with current fit to fix rootfs extending issue at 512M RAM" 
-            cp "$FIT" "$mnt/.wb-restore/factoryreset.fit"
+            chattr -i $CURRENT_FACTORY_FIT
+            cp "$FIT" "$CURRENT_FACTORY_FIT"
+            chattr +i $CURRENT_FACTORY_FIT
         else
             info "Factoryreset.fit already includes a fix for the 512MB RAM repartition issue (repartition-ramsize-fix compatibility)"
         fi
@@ -782,7 +784,12 @@ copy_this_fit_to_factory() {
     info "Copying $FIT to factory default location as requested"
 
     mount "$DATA_PART" "$mnt" || fatal "Unable to mount data partition"
-    cp "$FIT" "$mnt/.wb-restore/factoryreset.fit"
+    local factory_fit
+    factory_fit="$mnt/.wb-restore/factoryreset.fit"
+
+    chattr -i $factory_fit
+    cp "$FIT" "$factory_fit"
+    chattr +i $factory_fit
     umount "$mnt" || true
     sync
 }
@@ -798,13 +805,17 @@ maybe_update_current_factory_fit() {
     if [[ ! -e "$CURRENT_FACTORY_FIT" ]]; then
         info "No factory FIT found, storing this update as factory FIT to use as bootlet"
         mkdir -p "$mnt/.wb-restore"
-        cp "$FIT" "$mnt/.wb-restore/factoryreset.fit"
+        chattr -i $CURRENT_FACTORY_FIT
+        cp "$FIT" "$CURRENT_FACTORY_FIT"
+        chattr +i $CURRENT_FACTORY_FIT
     elif ! FIT="$CURRENT_FACTORY_FIT" fw_compatible single-rootfs; then
         info "Storing this update as factory FIT to use as bootlet"
         info "Old factory FIT will be kept as factoryreset.original.fit and will still be used to restore firmware"
 
-        mv "$mnt/.wb-restore/factoryreset.fit" "$mnt/.wb-restore/factoryreset.original.fit"
-        cp "$FIT" "$mnt/.wb-restore/factoryreset.fit"
+        chattr -i $CURRENT_FACTORY_FIT
+        mv "$CURRENT_FACTORY_FIT" "$mnt/.wb-restore/factoryreset.original.fit"
+        cp "$FIT" "$CURRENT_FACTORY_FIT"
+        chattr +i $CURRENT_FACTORY_FIT
     else
         info "Current factory FIT supports single-rootfs feature, keeping it"
     fi

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -788,7 +788,7 @@ copy_this_fit_to_factory() {
     local was_immutable=$(lsattr -l $factory_fit | grep "Immutable" || true)
     chattr -i $factory_fit
     cp "$FIT" "$factory_fit"
-    [[ -n "$was_immutable" ]] chattr +i $factory_fit
+    [[ -n "$was_immutable" ]] && chattr +i $factory_fit
     umount "$mnt" || true
     sync
 }

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -603,9 +603,10 @@ maybe_update_current_factory_tmpfs_size_fix(){
 
         if ! FIT="$CURRENT_FACTORY_FIT" fw_compatible repartition-ramsize-fix; then
             info "Replace factoryreset.fit with current fit to fix rootfs extending issue at 512M RAM" 
+            local was_immutable=$(lsattr -l $CURRENT_FACTORY_FIT | grep "Immutable" || true)
             chattr -i $CURRENT_FACTORY_FIT
             cp "$FIT" "$CURRENT_FACTORY_FIT"
-            chattr +i $CURRENT_FACTORY_FIT
+            [[ -n "$was_immutable" ]] && chattr +i $CURRENT_FACTORY_FIT
         else
             info "Factoryreset.fit already includes a fix for the 512MB RAM repartition issue (repartition-ramsize-fix compatibility)"
         fi
@@ -787,9 +788,10 @@ copy_this_fit_to_factory() {
     local factory_fit
     factory_fit="$mnt/.wb-restore/factoryreset.fit"
 
+    local was_immutable=$(lsattr -l $factory_fit | grep "Immutable" || true)
     chattr -i $factory_fit
     cp "$FIT" "$factory_fit"
-    chattr +i $factory_fit
+    [[ -n "$was_immutable" ]] chattr +i $factory_fit
     umount "$mnt" || true
     sync
 }
@@ -805,17 +807,16 @@ maybe_update_current_factory_fit() {
     if [[ ! -e "$CURRENT_FACTORY_FIT" ]]; then
         info "No factory FIT found, storing this update as factory FIT to use as bootlet"
         mkdir -p "$mnt/.wb-restore"
-        chattr -i $CURRENT_FACTORY_FIT
         cp "$FIT" "$CURRENT_FACTORY_FIT"
-        chattr +i $CURRENT_FACTORY_FIT
     elif ! FIT="$CURRENT_FACTORY_FIT" fw_compatible single-rootfs; then
         info "Storing this update as factory FIT to use as bootlet"
         info "Old factory FIT will be kept as factoryreset.original.fit and will still be used to restore firmware"
 
+        was_immutable=$(lsattr -l $CURRENT_FACTORY_FIT | grep "Immutable" || true)
         chattr -i $CURRENT_FACTORY_FIT
         mv "$CURRENT_FACTORY_FIT" "$mnt/.wb-restore/factoryreset.original.fit"
         cp "$FIT" "$CURRENT_FACTORY_FIT"
-        chattr +i $CURRENT_FACTORY_FIT
+        [[ -n "$was_immutable" ]] && chattr +i $CURRENT_FACTORY_FIT
     else
         info "Current factory FIT supports single-rootfs feature, keeping it"
     fi

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -603,10 +603,7 @@ maybe_update_current_factory_tmpfs_size_fix(){
 
         if ! FIT="$CURRENT_FACTORY_FIT" fw_compatible repartition-ramsize-fix; then
             info "Replace factoryreset.fit with current fit to fix rootfs extending issue at 512M RAM" 
-            local was_immutable=$(lsattr -l $CURRENT_FACTORY_FIT | grep "Immutable" || true)
-            chattr -i $CURRENT_FACTORY_FIT
-            cp "$FIT" "$CURRENT_FACTORY_FIT"
-            [[ -n "$was_immutable" ]] && chattr +i $CURRENT_FACTORY_FIT
+            copy_this_fit_to_factory
         else
             info "Factoryreset.fit already includes a fix for the 512MB RAM repartition issue (repartition-ramsize-fix compatibility)"
         fi
@@ -812,11 +809,9 @@ maybe_update_current_factory_fit() {
         info "Storing this update as factory FIT to use as bootlet"
         info "Old factory FIT will be kept as factoryreset.original.fit and will still be used to restore firmware"
 
-        was_immutable=$(lsattr -l $CURRENT_FACTORY_FIT | grep "Immutable" || true)
-        chattr -i $CURRENT_FACTORY_FIT
-        mv "$CURRENT_FACTORY_FIT" "$mnt/.wb-restore/factoryreset.original.fit"
-        cp "$FIT" "$CURRENT_FACTORY_FIT"
-        [[ -n "$was_immutable" ]] && chattr +i $CURRENT_FACTORY_FIT
+        cp "$CURRENT_FACTORY_FIT" "$mnt/.wb-restore/factoryreset.original.fit"
+        sync
+        copy_this_fit_to_factory
     else
         info "Current factory FIT supports single-rootfs feature, keeping it"
     fi

--- a/utils/lib/wb-image-update/fix-broken-fit.sh
+++ b/utils/lib/wb-image-update/fix-broken-fit.sh
@@ -34,8 +34,10 @@ if of_machine_match "wirenboard,wirenboard-7xx" || of_machine_match "wirenboard,
                 if [[ "$FACTORYRESET_SHA256" == "$broken" ]]; then
                     echo "Broken factory FIT found, downloading a working one"
                     wget -O "${FACTORYRESET_FIT}.new" "${URL}?broken&from=${FACTORYRESET_SHA256}&serial=$(wb-gen-serial -s)"
+                    chattr -i $FACTORYRESET_FIT
                     mv "${FACTORYRESET_FIT}.new" "$FACTORYRESET_FIT"
                     sync
+                    chattr +i $FACTORYRESET_FIT
                     break
                 fi
             done

--- a/utils/lib/wb-image-update/fix-broken-fit.sh
+++ b/utils/lib/wb-image-update/fix-broken-fit.sh
@@ -34,10 +34,11 @@ if of_machine_match "wirenboard,wirenboard-7xx" || of_machine_match "wirenboard,
                 if [[ "$FACTORYRESET_SHA256" == "$broken" ]]; then
                     echo "Broken factory FIT found, downloading a working one"
                     wget -O "${FACTORYRESET_FIT}.new" "${URL}?broken&from=${FACTORYRESET_SHA256}&serial=$(wb-gen-serial -s)"
+                    local was_immutable=$(lsattr -l $FACTORYRESET_FIT | grep "Immutable" || true)
                     chattr -i $FACTORYRESET_FIT
                     mv "${FACTORYRESET_FIT}.new" "$FACTORYRESET_FIT"
                     sync
-                    chattr +i $FACTORYRESET_FIT
+                    [[ -n "$was_immutable" ]] && chattr +i $FACTORYRESET_FIT
                     break
                 fi
             done


### PR DESCRIPTION
Вешаем immutable-атрибут на factory-fit. Иногда надо менять factory-fit -> играемся с chattr. 

Всегда восстанавливаем изначальный immutable-state, т.к. для корректной работы c immutable-factory-fit нужен починеный fit-info => иначе, если обновление через apt прилетит на уже выпущенные контроллеры - всё сломается (не смогут прошиться в бутлете)


сейчас какие-то проблемы со сборкой fit-а; чуть позже добавлю на потыкать