### PR TITLE
Feature/wb8 debug network update

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.25.0) stable; urgency=medium
+
+  * install_update: replace factory fit, if wb8-debug-network-update-fix is not supported
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Mon, 21 Oct 2024 14:15:16 +0300
+
 wb-utils (4.24.0) stable; urgency=medium
 
   * support immutable factory-fit

--- a/utils/lib/wb-image-update/fit/build.sh
+++ b/utils/lib/wb-image-update/fit/build.sh
@@ -89,6 +89,7 @@ echo -n "+fit-factory-reset " >> /var/lib/wb-image-update/firmware-compatible
 echo -n "+force-repartition " >> /var/lib/wb-image-update/firmware-compatible
 echo -n "+repartition-ramsize-fix " >> /var/lib/wb-image-update/firmware-compatible
 echo -n "+fit-immutable-support " >> /var/lib/wb-image-update/firmware-compatible
+echo -n "+wb8-debug-network-update-fix " > /var/lib/wb-image-update/firmware-compatible
 
 if of_machine_match "wirenboard,wirenboard-8xx"; then
     KERNEL_IMAGE="Image.gz"

--- a/utils/lib/wb-image-update/fit/build.sh
+++ b/utils/lib/wb-image-update/fit/build.sh
@@ -89,7 +89,7 @@ echo -n "+fit-factory-reset " >> /var/lib/wb-image-update/firmware-compatible
 echo -n "+force-repartition " >> /var/lib/wb-image-update/firmware-compatible
 echo -n "+repartition-ramsize-fix " >> /var/lib/wb-image-update/firmware-compatible
 echo -n "+fit-immutable-support " >> /var/lib/wb-image-update/firmware-compatible
-echo -n "+wb8-debug-network-update-fix " > /var/lib/wb-image-update/firmware-compatible
+echo -n "+wb8-debug-network-update-fix " >> /var/lib/wb-image-update/firmware-compatible
 
 if of_machine_match "wirenboard,wirenboard-8xx"; then
     KERNEL_IMAGE="Image.gz"

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -793,7 +793,8 @@ copy_this_fit_to_factory() {
     sync
 }
 
-maybe_update_current_factory_fit() {
+update_current_factory_fit_if_not_compatible() {
+    local fit_compat_features=$1
     local mnt
     mnt=$(mktemp -d)
     mount "$DATA_PART" "$mnt" || fatal "Unable to mount data partition"
@@ -801,19 +802,32 @@ maybe_update_current_factory_fit() {
     # check if current fit supports +single-rootfs feature
     CURRENT_FACTORY_FIT="$mnt/.wb-restore/factoryreset.fit"
 
+    info "Checking, $CURRENT_FACTORY_FIT supports features: $fit_compat_features"
     if [[ ! -e "$CURRENT_FACTORY_FIT" ]]; then
         info "No factory FIT found, storing this update as factory FIT to use as bootlet"
         mkdir -p "$mnt/.wb-restore"
         cp "$FIT" "$CURRENT_FACTORY_FIT"
-    elif ! FIT="$CURRENT_FACTORY_FIT" fw_compatible single-rootfs; then
-        info "Storing this update as factory FIT to use as bootlet"
+        umount "$mnt" || true
+        sync
+        return
+    fi
+
+    local features_required
+    local features_unsupported
+    IFS=' ' read -ra features_required <<< "$fit_compat_features"
+    for feature in "${features_required[@]}"; do
+        FIT="$CURRENT_FACTORY_FIT" fw_compatible $feature || features_unsupported="$features_unsupported $feature"
+        fw_compatible $feature || die "$feature is required, but not supported in $FIT! Choose another FIT"
+    done
+    if [[ -n "$features_unsupported" ]]; then
+        info "Storing this update as factory FIT to use as bootlet (supports $fit_compat_features)"
         info "Old factory FIT will be kept as factoryreset.original.fit and will still be used to restore firmware"
 
         cp "$CURRENT_FACTORY_FIT" "$mnt/.wb-restore/factoryreset.original.fit"
         sync
         copy_this_fit_to_factory
     else
-        info "Current factory FIT supports single-rootfs feature, keeping it"
+        info "Current factory FIT supports: $fit_compat_features, keeping it"
     fi
 
     umount "$mnt" || true
@@ -1074,7 +1088,7 @@ else
 fi
 
 if ! flag_set from-initramfs && flag_set "force-repartition"; then
-    maybe_update_current_factory_fit
+    update_current_factory_fit_if_not_compatible "single-rootfs"
     update_after_reboot
 fi
 
@@ -1124,7 +1138,7 @@ fi
 if flag_set copy-to-factory; then
     copy_this_fit_to_factory
 elif flag_set factoryreset; then
-    maybe_update_current_factory_fit
+    update_current_factory_fit_if_not_compatible "single-rootfs"
 fi
 
 info "Switching to new rootfs"

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -785,10 +785,15 @@ copy_this_fit_to_factory() {
     local factory_fit
     factory_fit="$mnt/.wb-restore/factoryreset.fit"
 
-    local was_immutable=$(lsattr -l $factory_fit | grep "Immutable" || true)
-    chattr -i $factory_fit
-    cp "$FIT" "$factory_fit"
-    [[ -n "$was_immutable" ]] && chattr +i $factory_fit
+    if FIT="$factory_fit" fw_compatible "fit-immutable-support"; then
+        info "Saving immutability state of $factory_fit"
+        local was_immutable=$(lsattr -l $factory_fit | grep "Immutable" || true)
+        chattr -i $factory_fit
+        cp "$FIT" "$factory_fit"
+        [[ -n "$was_immutable" ]] && chattr +i $factory_fit
+    else  # no chattr / lsattr in factory fit
+        cp "$FIT" "$factory_fit"
+    fi
     umount "$mnt" || true
     sync
 }

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -1088,7 +1088,7 @@ else
 fi
 
 if ! flag_set from-initramfs && flag_set "force-repartition"; then
-    update_current_factory_fit_if_not_compatible "single-rootfs"
+    update_current_factory_fit_if_not_compatible "single-rootfs wb8-debug-network-update-fix"
     update_after_reboot
 fi
 
@@ -1138,7 +1138,7 @@ fi
 if flag_set copy-to-factory; then
     copy_this_fit_to_factory
 elif flag_set factoryreset; then
-    update_current_factory_fit_if_not_compatible "single-rootfs"
+    update_current_factory_fit_if_not_compatible "single-rootfs wb8-debug-network-update-fix"
 fi
 
 info "Switching to new rootfs"


### PR DESCRIPTION
на выпущенных нами wb8 не работает обновление через debug-network (а потроха этого лежать в factory-fit выпущенных wb)

=> надо подменять factory-fit, если в нём уже всё починено

для этого:

- +wb8-debug-network-update-fix - маркер починенности
- переделал логику замены factory-fit-a, чтобы кушала несколько fit-compatible вместо одного

как погонять:
1) убедиться, что вот [ето](https://wirenboard.com/wiki/Wiren_Board_8_Firmware_Update#%D0%9F%D1%80%D0%BE%D1%88%D0%B8%D0%B2%D0%BA%D0%B0_%D1%87%D0%B5%D1%80%D0%B5%D0%B7_Debug_Network) не работает
2) сделать FR с флешки [fit-ом](https://jenkins.wirenboard.com/job/pipelines/job/build-image/8198/)
3) убедиться, что 1) работает (любым фитом)