### PR TITLE
install_update: trigger FR from factoryreset.original.fit only if sin…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.25.1) stable; urgency=medium
+
+  * install_update: trigger FR from factoryreset.original.fit only if single-rootfs is not supported here
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Wed, 20 Nov 2024 16:02:21 +0300
+
 wb-utils (4.25.0) stable; urgency=medium
 
   * install_update: replace factory fit, if wb8-debug-network-update-fix is not supported

--- a/utils/lib/wb-image-update/fit/build.sh
+++ b/utils/lib/wb-image-update/fit/build.sh
@@ -90,6 +90,7 @@ echo -n "+force-repartition " >> /var/lib/wb-image-update/firmware-compatible
 echo -n "+repartition-ramsize-fix " >> /var/lib/wb-image-update/firmware-compatible
 echo -n "+fit-immutable-support " >> /var/lib/wb-image-update/firmware-compatible
 echo -n "+wb8-debug-network-update-fix " >> /var/lib/wb-image-update/firmware-compatible
+echo -n "+wrong-ab-layout-fix " >> /var/lib/wb-image-update/firmware-compatible
 
 if of_machine_match "wirenboard,wirenboard-8xx"; then
     KERNEL_IMAGE="Image.gz"

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -407,6 +407,7 @@ ensure_enlarged_rootfs_parttable() {
     info "Expanding filesystem on this partition"
     local e2fs_undofile
     e2fs_undofile=$(mktemp)
+    run_tool e2fsck -y "$ROOTFS1_PART"
     run_tool resize2fs -z "$e2fs_undofile" "$ROOTFS1_PART" || {
         info "Filesystem expantion failed, restoring everything"
         run_tool e2undo "$e2fs_undofile" "$ROOTFS1_PART" || true
@@ -1093,7 +1094,7 @@ else
 fi
 
 if ! flag_set from-initramfs && flag_set "force-repartition"; then
-    update_current_factory_fit_if_not_compatible "single-rootfs wb8-debug-network-update-fix"
+    update_current_factory_fit_if_not_compatible "single-rootfs wb8-debug-network-update-fix wrong-ab-layout-fix"
     update_after_reboot
 fi
 
@@ -1143,7 +1144,7 @@ fi
 if flag_set copy-to-factory; then
     copy_this_fit_to_factory
 elif flag_set factoryreset; then
-    update_current_factory_fit_if_not_compatible "single-rootfs wb8-debug-network-update-fix"
+    update_current_factory_fit_if_not_compatible "single-rootfs wb8-debug-network-update-fix wrong-ab-layout-fix"
 fi
 
 info "Switching to new rootfs"

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -839,7 +839,7 @@ update_current_factory_fit_if_not_compatible() {
     sync
 }
 
-maybe_trigger_original_factory_fit() {
+maybe_trigger_original_factory_fit_to_restore_ab() {
     local mnt
     mnt=$(mktemp -d)
     mount "$DATA_PART" "$mnt" || fatal "Unable to mount data partition"
@@ -847,8 +847,8 @@ maybe_trigger_original_factory_fit() {
     # check if current fit supports +single-rootfs feature
     ORIGINAL_FACTORY_FIT="$mnt/.wb-restore/factoryreset.original.fit"
 
-    if [ -e "$ORIGINAL_FACTORY_FIT" ]; then
-        info "Original factory FIT exists, ensuring A/B rootfs scheme and use it to restore firmware"
+    if [ -e "$ORIGINAL_FACTORY_FIT" ] && (! FIT=$ORIGINAL_FACTORY_FIT fw_compatible "single-rootfs"); then
+        info "Original factory FIT exists and not support single-rootfs, ensuring A/B rootfs scheme and use it to restore firmware"
         ensure_ab_rootfs_parttable || fatal "Failed to restore A/B rootfs scheme"
 
         info "Decoding current flags from '$FLAGS'"
@@ -1065,7 +1065,7 @@ if flag_set factoryreset; then
 fi
 
 if flag_set from-emmc-factoryreset; then
-    maybe_trigger_original_factory_fit
+    maybe_trigger_original_factory_fit_to_restore_ab
 fi
 
 if flag_set force-compatible; then


### PR DESCRIPTION
пока тыкал прошивание WB (около сборки fit-ов) - нашел странную косяку:
wb на старых релизах (до 2410) => FR-им на 2410 с флешки => гут => загрузились, ребут, делаем FR кнопкой (без флешки) => wb пытается вернуться на A/B схему и ломается (см миником)
[123.txt](https://github.com/user-attachments/files/17832445/123.txt)

причина - для работы debug-network в wb8 надо было заменять factory-fit. А дальше - оказалась логика вида "есть factoryreset.original.fit => пытаемся в A/B схему и рекурсим сами в себя".

В общем, проблема - я не знал, что .original.fit механизм - только для возвращения на A/B (нейминг - моё почтение) => подкрутил логику. Потыкать можно (и нужно, кмк) - взяв [спец-фит](https://jenkins.wirenboard.com/job/pipelines/job/build-image/8540/)

предполагаю, cо старыми контроллерами на A/B это чудо работает - пот часть install_update.sh у них в factory-fit-e (и не та, что видим здесь) => вот и не рекурсят