### PR TITLE
Fix usb-otg bug with NetworkManager

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.25.4) stable; urgency=medium
+
+  * Fix usb-otg bug with Debug Network
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Mon, 31 Mar 2025 10:28:50 +0300
+
 wb-utils (4.25.3) stable; urgency=medium
 
   * Fix text in logs. No functional changes

--- a/utils/lib/wb-usb-otg/wb-usb-otg-common.sh
+++ b/utils/lib/wb-usb-otg/wb-usb-otg-common.sh
@@ -4,9 +4,27 @@ IMAGE_FILE=/usr/lib/wb-utils/wb-usb-otg/mass_storage.img
 USBDEV="usb0"
 USBGADGET_CONFIG=/sys/kernel/config/usb_gadget/g1
 RNDIS_IFNAME="dbg%d"
+NETWORK_CONNAME="wb-debug"
+NETWORK_TIMEOUT=5
 
 log() {
     >&2 echo "${FUNCNAME[2]}: $*"
+}
+
+wait_for_nm_connection() {
+    log "Waiting for NM connection ${NETWORK_CONNAME}"
+
+    timeout=${NETWORK_TIMEOUT}
+    while [[ ! $(nmcli c | grep ${NETWORK_CONNAME}) ]]; do
+        sleep 1
+        ((timeout--))
+        if [ $timeout -eq 0 ]; then
+            log "Timeout waiting for NM connection ${NETWORK_CONNAME}"
+            return 1
+        fi
+    done
+    log "NM connection ${NETWORK_CONNAME} is up"
+    return 0
 }
 
 setup_usb() {

--- a/utils/lib/wb-usb-otg/wb-usb-otg-start.sh
+++ b/utils/lib/wb-usb-otg/wb-usb-otg-start.sh
@@ -5,6 +5,7 @@
 trap "config_reset; remove_usb_gadget; exit 1" ERR
 
 log "wb-usb-otg-start"
+wait_for_nm_connection
 setup_device
 enable_profile
 mount_ms


### PR DESCRIPTION
After=NetworkManager работает не очень хорошо. NM имеет тип сервиса dbus и срабатывает когда NM публикует свое имя на шине. Конфигурация и запуск сети выполняются уже после этого. Из за этого получается, что NM и wb-usb-otg работают одновременно и получается баг: NM думает что соединение есть и поднято, фактически tcpdump не видит ни одного пакета как будто физической связи вообще нет.