### PR TITLE
Fix dependencies

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 wb-utils (4.25.5) stable; urgency=medium
 
-  * Fix dependencies
+  * Add missed dependencies (e2fsprogs, ppp, python3)
+  * Remove unused dependencies (parted)
 
  -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 18 Apr 2025 17:30:00 +0400
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.25.5) stable; urgency=medium
+
+  * Fix dependencies
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 18 Apr 2025 17:30:00 +0400
+
 wb-utils (4.25.4) stable; urgency=medium
 
   * Fix usb-otg bug with Debug Network

--- a/debian/control
+++ b/debian/control
@@ -1,5 +1,5 @@
 Source: wb-utils
-Maintainer: Evgeny Boger <boger@contactless.ru>
+Maintainer: Wiren Board team <info@wirenboard.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
@@ -8,10 +8,27 @@ Homepage: https://github.com/wirenboard/wb-utils
 
 Package: wb-utils
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, lsb-base (>= 4.1), u-boot-tools-wb (>= 2015.07+wb-3), inotify-tools, pv, jq,
-         nginx-extras, python3-wb-common (>= 2.0.0~~), wb-configs (>= 3.31.0~~), util-linux,
-         linux-image-wb6 (>= 5.10.35-wb108~~) | linux-image-wb7 (>= 5.10.35-wb130~~) | linux-image-wb8, wb-bootlet,
-         device-tree-compiler, parted, rsync, gpiod, systemd (>= 243), wb-ec-firmware
+Depends: ${shlibs:Depends},
+         ${misc:Depends},
+         lsb-base (>= 4.1),
+         u-boot-tools-wb (>= 2015.07+wb-3),
+         inotify-tools,
+         pv,
+         jq,
+         nginx-extras,
+         python3,
+         python3-wb-common (>= 2.0.0~~),
+         wb-configs (>= 3.31.0~~),
+         util-linux,
+         ppp,
+         e2fsprogs,
+         linux-image-wb6 (>= 5.10.35-wb108~~) | linux-image-wb7 (>= 5.10.35-wb130~~) | linux-image-wb8,
+         wb-bootlet,
+         device-tree-compiler,
+         rsync,
+         gpiod,
+         systemd (>= 243),
+         wb-ec-firmware
 Conflicts: wb-configs (<< 1.69.4)
 Breaks: wb-homa-ism-radio (<< 1.17.2), wb-rules-system (<< 1.6.1), wb-mqtt-serial (<< 1.47.2), wb-mqtt-homeui (<< 1.7.1),
         u-boot-wb7 (<< 2:2021.10+wb1.5.0~~), u-boot-wb6 (<< 2:2021.10+wb1.6.0~~)


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
* add e2fsprogs to Depends
в bullseye ставилось как часть minbase, в trixie уже не входит в minbase, что приводит к ошибке при установке:
```
file /sbin/resize2fs <- /sbin/resize2fs
cp: cannot stat '/sbin/resize2fs': No such file or directory
dpkg: error processing package wb-utils (--configure):
 installed wb-utils package post-installation script subprocess returned error exit status 1
Errors were encountered while processing:
 wb-utils
```
Пруф:
```sh
$ debootstrap --foreign --verbose --arch arm64 --variant=minbase trixie out-trixie http://debian-mirror.wirenboard.com/debian
$ find out-trixie/ -name resize2fs
<nothing>
$ debootstrap --foreign --verbose --arch arm64 --variant=minbase bullseye out-bullseye http://debian-mirror.wirenboard.com/debian
$ find out-bullseye/ -name resize2fs
out-bullseye/usr/sbin/resize2fs
```

* remove parted from Depends
Было добавлено в [2.3](https://github.com/wirenboard/wb-utils/pull/24) для partprobe, после [4.0.0](https://github.com/wirenboard/wb-utils/pull/44) не используется.

* add ppp to Depends
wb-utils использует /usr/sbin/chat, сейчас ставится как зависимость для task-wb-base-system.

* add python3 to Depends
fix lintian error: `E: wb-utils: python3-script-but-no-python3-dep usr/bin/wb-gen-serial #!python3`
___________________________________
**Что поменялось для пользователей:**
Ничего.

___________________________________
**Как проверял/а:**


