### PR TITLE
Set offset/size from dt to /etc/fw_env.config

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.26.0) stable; urgency=medium
+
+  * Fill /etc/fw_env.config with uboot-env-offset/size from device tree if any
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 04 Jun 2025 17:30:00 +0400
+
 wb-utils (4.25.5) stable; urgency=medium
 
   * Add missed dependencies (e2fsprogs, ppp, python3)

--- a/utils/lib/prepare/wb-prepare.sh
+++ b/utils/lib/prepare/wb-prepare.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+. /usr/lib/wb-utils/wb_env.sh
+
 ROOT_PARTITION=$(mount -l | grep " / " | cut -d " " -f1)
 
 # legacy: load log_*_msg functions
@@ -273,7 +275,7 @@ wb_run_scripts()
     fi
 }
 
-update_fw_env_config()
+wb_update_fw_env_config()
 {
     local config_file="/etc/fw_env.config"
     local device_name="/dev/mmcblk0"
@@ -292,7 +294,7 @@ update_fw_env_config()
     fi
 
     if [[ ! "$offset" =~ ^[0-9]+$ ]] || [[ ! "$size" =~ ^[0-9]+$ ]]; then
-        log_error_msg "Invalid offset ($offset) or size ($size) - not numeric"
+        log_failure_msg "Invalid offset ($offset) or size ($size) - not numeric"
         return 1
     fi
 
@@ -317,8 +319,6 @@ EOF
 wb_firstboot()
 {
     log_action_msg "Preparing rootfs for the first boot"
-
-    update_fw_env_config
 
     wb_check_data && local data_mounted=1
 
@@ -371,6 +371,7 @@ wb_firstboot()
 
 case "$1" in
   firstboot)
+    wb_update_fw_env_config
     wb_prepare_filesystems
     wb_firstboot
     exit $?

--- a/utils/lib/prepare/wb-prepare.sh
+++ b/utils/lib/prepare/wb-prepare.sh
@@ -279,20 +279,20 @@ update_fw_env_config()
     local device_name="/dev/mmcblk0"
     local offset size offset_hex size_hex
 
-    echo "Reading environment configuration from device tree..."
+    log_action_msg "Reading uboot env offset/size from device tree..."
 
     if ! offset=$(dtc -I fs -O dtb /proc/device-tree 2>/dev/null | fdtget - /wirenboard uboot-env-offset 2>/dev/null); then
-        echo "Error: Could not read uboot-env-offset from device tree"
+        log_warning_msg "Could not read uboot-env-offset from device tree. Keeping old fw_env.config from rootfs"
         return 1
     fi
 
     if ! size=$(dtc -I fs -O dtb /proc/device-tree 2>/dev/null | fdtget - /wirenboard uboot-env-size 2>/dev/null); then
-        echo "Error: Could not read uboot-env-size from device tree"
+        log_warning_msg "Could not read uboot-env-size from device tree. Keeping old fw_env.config from rootfs"
         return 1
     fi
 
     if [[ ! "$offset" =~ ^[0-9]+$ ]] || [[ ! "$size" =~ ^[0-9]+$ ]]; then
-        echo "Error: Invalid offset ($offset) or size ($size) - not numeric"
+        log_error_msg "Invalid offset ($offset) or size ($size) - not numeric"
         return 1
     fi
 
@@ -310,7 +310,7 @@ update_fw_env_config()
 # MTD device name   Device offset   Env. size   Flash sector size
 $device_name        $offset_hex         $size_hex
 EOF
-    echo "Successfully updated $config_file"
+    log_action_msg "Successfully updated $config_file"
 }
 
 # This function should be called only on first boot of the rootfs

--- a/utils/lib/prepare/wb-prepare.sh
+++ b/utils/lib/prepare/wb-prepare.sh
@@ -281,13 +281,13 @@ update_fw_env_config()
 
     echo "Reading environment configuration from device tree..."
 
-    if ! offset=$(dtc -I fs -O dtb /proc/device-tree 2>/dev/null | fdtget - /wirenboard env-offset 2>/dev/null); then
-        echo "Error: Could not read env-offset from device tree"
+    if ! offset=$(dtc -I fs -O dtb /proc/device-tree 2>/dev/null | fdtget - /wirenboard uboot-env-offset 2>/dev/null); then
+        echo "Error: Could not read uboot-env-offset from device tree"
         return 1
     fi
 
-    if ! size=$(dtc -I fs -O dtb /proc/device-tree 2>/dev/null | fdtget - /wirenboard env-size 2>/dev/null); then
-        echo "Error: Could not read env-size from device tree"
+    if ! size=$(dtc -I fs -O dtb /proc/device-tree 2>/dev/null | fdtget - /wirenboard uboot-env-size 2>/dev/null); then
+        echo "Error: Could not read uboot-env-size from device tree"
         return 1
     fi
 

--- a/utils/lib/prepare/wb-prepare.sh
+++ b/utils/lib/prepare/wb-prepare.sh
@@ -281,12 +281,12 @@ update_fw_env_config()
 
     log_action_msg "Reading uboot env offset/size from device tree..."
 
-    if ! offset=$(dtc -I fs -O dtb /proc/device-tree 2>/dev/null | fdtget - /wirenboard uboot-env-offset 2>/dev/null); then
+    if ! offset=$(wb_source of && of_get_prop_ulong wirenboard uboot-env-offset); then
         log_warning_msg "Could not read uboot-env-offset from device tree. Keeping old fw_env.config from rootfs"
         return 1
     fi
 
-    if ! size=$(dtc -I fs -O dtb /proc/device-tree 2>/dev/null | fdtget - /wirenboard uboot-env-size 2>/dev/null); then
+    if ! size=$(wb_source of && of_get_prop_ulong wirenboard uboot-env-size); then
         log_warning_msg "Could not read uboot-env-size from device tree. Keeping old fw_env.config from rootfs"
         return 1
     fi

--- a/utils/lib/prepare/wb-prepare.sh
+++ b/utils/lib/prepare/wb-prepare.sh
@@ -280,29 +280,22 @@ wb_update_fw_env_config()
 {
     local config_file="/etc/fw_env.config"
     local device_name="/dev/mmcblk0"
-    local offset size offset_hex size_hex
+    local offset size
 
     log_action_msg "Reading uboot env offset/size from device tree..."
 
     if of_has_prop "wirenboard" "uboot-env-offset"; then
-        offset=$(of_get_prop_ulong "wirenboard" "uboot-env-offset")
-        offset_hex=$(printf "0x%x" $offset)
+        offset=$(of_get_prop_str "wirenboard" "uboot-env-offset")
     else
         log_warning_msg "Could not read uboot-env-offset from device tree. Keeping old fw_env.config from rootfs"
         return 0
     fi
 
     if of_has_prop "wirenboard" "uboot-env-size"; then
-        size=$(of_get_prop_ulong "wirenboard" "uboot-env-size")
-        size_hex=$(printf "0x%x" $size)
+        size=$(of_get_prop_str "wirenboard" "uboot-env-size")
     else
         log_warning_msg "Could not read uboot-env-size from device tree. Keeping old fw_env.config from rootfs"
         return 0
-    fi
-
-    if [[ ! "$offset" =~ ^[0-9]+$ ]] || [[ ! "$size" =~ ^[0-9]+$ ]]; then
-        log_failure_msg "Invalid offset ($offset) or size ($size) - not numeric"
-        return 1
     fi
 
     cat > "$config_file" << EOF
@@ -314,7 +307,7 @@ wb_update_fw_env_config()
 # sectors"
 
 # MTD device name   Device offset   Env. size   Flash sector size
-$device_name        $offset_hex         $size_hex
+$device_name        $offset             $size
 EOF
     log_action_msg "Successfully updated $config_file"
 }

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -2,9 +2,6 @@
 
 set -e
 
-. /usr/lib/wb-utils/wb_env.sh
-wb_source "of"
-
 ROOTDEV="${ROOTDEV:-/dev/mmcblk0}"
 TMPDIR="${TMPDIR:-/dev/shm}"
 
@@ -1052,15 +1049,16 @@ wb_update_fw_env_config()
 
     info "Reading uboot env offset/size from device tree..."
 
-    if of_has_prop "wirenboard" "uboot-env-offset"; then
-        offset=$(of_get_prop_str "wirenboard" "uboot-env-offset")
+    local node=$(readlink -f "/proc/device-tree/wirenboard")
+    if [[ -e "$node/uboot-env-offset" ]]; then
+        offset=$(< "$node/uboot-env-offset" sed 's/\x0$//g' | tr '\000' ' ')
     else
         info "Could not read uboot-env-offset from device tree. Keeping old fw_env.config from rootfs"
         return 0
     fi
 
-    if of_has_prop "wirenboard" "uboot-env-size"; then
-        size=$(of_get_prop_str "wirenboard" "uboot-env-size")
+    if [[ -e "$node/uboot-env-size" ]]; then
+        size=$(< "$node/uboot-env-size" sed 's/\x0$//g' | tr '\000' ' ')
     else
         info "Could not read uboot-env-size from device tree. Keeping old fw_env.config from rootfs"
         return 0


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Смотрим в DT при firstboot, если там есть env-offset и env-size, то обновляем /etc/fw_env.conf.

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
1. Погонял с убутом из https://github.com/wirenboard/u-boot-private/pull/58
```sh
$ /usr/lib/wb-utils/prepare/wb-prepare.sh firstboot
Reading uboot env offset/size from device tree....
Successfully updated /etc/fw_env.config.
...
```
2. Погонял со старым убутом
```sh
$ /usr/lib/wb-utils/prepare/wb-prepare.sh firstboot
Reading uboot env offset/size from device tree....
Could not read uboot-env-offset from device tree. Keeping old fw_env.config from rootfs ... (warning).
...
```