### PR TITLE
add extended rootfs support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,8 @@ install: build_mass_storage
 
 	install -Dm0755 -t $(IMAGEUPDATE_POSTINST_DIR) \
 		utils/lib/wb-image-update/postinst/10update-u-boot \
-		utils/lib/wb-image-update/postinst/10update-wbec-firmware
+		utils/lib/wb-image-update/postinst/10update-wbec-firmware \
+		utils/lib/wb-image-update/postinst/20fstab-extended
 
 	install -Dm0755 -t $(FIT_FILES_DIR) \
 		utils/lib/wb-image-update/fit/build.sh \

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.27.0) stable; urgency=medium
+
+  * add extended rootfs support
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 23 Jul 2025 15:10:00 +0400
+
 wb-utils (4.26.3) stable; urgency=medium
 
   * Remove obsolete code, refactoring

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -162,6 +162,10 @@ disk_layout_is_ab() {
     [ "$(blockdev --getsz "$ROOTFS1_PART")" -eq "$(blockdev --getsz "$ROOTFS2_PART")" ]
 }
 
+disk_layout_is_extended() {
+    [ ! -e "$DATA_PART" ]
+}
+
 fw_compatible() {
     local feature="$1"
     local fw_compat

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -13,6 +13,7 @@
 TMPDIR="/dev/shm"
 FIT=""
 FLAGS=""
+ARGS=()
 
 EMMC="/dev/mmcblk0"
 # for factory reset
@@ -210,6 +211,18 @@ check_firmware_compatible() {
 
 #---------------------------------------- main ----------------------------------------
 
+while [[ -n "$1" ]]; do
+	case "$1" in
+		--*|-*)
+			FLAGS+="$1 "
+			;;
+		*)
+			ARGS+=("$1")
+			;;
+	esac
+	shift
+done
+
 flag_set no-mqtt && {
 	mqtt_status() { :; }
 
@@ -265,18 +278,11 @@ EOF
 
 [[ $EUID != 0 ]] && die "Need root privileges to install update"
 
-while [[ -n "$1" ]]; do
-	case "$1" in
-		--*|-*)
-			FLAGS+="$1 "
-			;;
-		*)
-			[[ -n "$FIT" ]] && die "Bad arguments"
-			FIT=`readlink -f $1`
-			;;
-	esac
-	shift
-done
+if [[ ${#ARGS[@]} -ne 1 ]]; then
+	die "Bad arguments"
+fi
+
+FIT=`readlink -f ${ARGS[0]}`
 
 [[ -f "$FIT" ]] || die "FIT $FIT not found"
 

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -35,8 +35,7 @@ rm_fit() {
 		chattr -i $FIT
 		rm -f "$FIT"
 		sync
-		# FIXME: "!!! Error at line 1361 ([[ -n "$was_immutable" ]])"
-		#[[ -n "$was_immutable" ]] && chattr +i $FACTORY_FIT
+		[[ -n "$was_immutable" ]] && chattr +i $FACTORY_FIT
 	else
 		rm -f "$FIT"
 	fi

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -31,7 +31,7 @@ rm_fit() {
 	info "Removing FIT $FIT"
 	if [ "$FIT" -ef "$FACTORY_FIT" ]; then
 		info "$FIT is a hardlink to factory-fit; saving factory-fit immutability"
-		was_immutable=$(lsattr -l $FACTORY_FIT | grep "Immutable" || true)
+		local was_immutable=$(lsattr -l $FACTORY_FIT | grep "Immutable" || true)
 		chattr -i $FIT
 		rm -f "$FIT"
 		sync
@@ -202,23 +202,6 @@ check_firmware_compatible() {
 
 #---------------------------------------- main ----------------------------------------
 
-[[ $EUID != 0 ]] && die "Need root privileges to install update"
-
-while [[ -n "$1" ]]; do
-	case "$1" in
-		--*|-*)
-			FLAGS+="$1 "
-			;;
-		*)
-			[[ -n "$FIT" ]] && die "Bad arguments"
-			FIT=`readlink -f $1`
-			;;
-	esac
-	shift
-done
-
-[[ -f "$FIT" ]] || die "FIT $FIT not found"
-
 flag_set no-mqtt && {
 	mqtt_status() { :; }
 
@@ -271,6 +254,23 @@ EOF
 		true
 	}
 }
+
+[[ $EUID != 0 ]] && die "Need root privileges to install update"
+
+while [[ -n "$1" ]]; do
+	case "$1" in
+		--*|-*)
+			FLAGS+="$1 "
+			;;
+		*)
+			[[ -n "$FIT" ]] && die "Bad arguments"
+			FIT=`readlink -f $1`
+			;;
+	esac
+	shift
+done
+
+[[ -f "$FIT" ]] || die "FIT $FIT not found"
 
 flag_set no-mqtt && {
 	# check factory reset condition here and add flag in this case

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -284,7 +284,7 @@ flag_set no-mqtt && {
 	# check factory reset condition here and add flag in this case
 	case $FIT in
 		*FACTORYRESET*|*factoryreset*)
-			if flag_set no-confirm; then
+			if flag_set no-confirm || ! flag_set no-mqtt; then
 				echo -e "\nFactory reset (confirm is not required)!\n"
 				FLAGS+="--factoryreset "
 			elif prompt_update_factoryreset; then

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -7,7 +7,7 @@
 #   DO NOT ADD ANY NEW FEATURES HERE!
 #
 # A great place for the new update features is
-# utils/lib/wb-image-update/fit/install_image.sh file
+# utils/lib/wb-image-update/fit/install_update.sh file
 # in this repository.
 
 TMPDIR="/dev/shm"

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -33,7 +33,7 @@ rm_fit() {
 	if [ "$FIT" -ef "$FACTORY_FIT" ]; then
 		info "$FIT is a hardlink to factory-fit; saving factory-fit immutability"
 		local was_immutable=$(lsattr -l $FACTORY_FIT | grep "Immutable" || true)
-		chattr -i $FIT
+		chattr -i "$FIT"
 		rm -f "$FIT"
 		sync
 		[[ -n "$was_immutable" ]] && chattr +i $FACTORY_FIT || true
@@ -43,7 +43,7 @@ rm_fit() {
 }
 
 led() {
-	echo $3 > /sys/class/leds/$1/$2 || true
+	echo "$3" > "/sys/class/leds/$1/$2" || true
 }
 
 led_process() {
@@ -112,12 +112,12 @@ fit_prop() {
 	local node=$1
 	local prop=$2
 
-	local tmp=`fit_info -f $FIT -n $node -p $prop`
-	local len=`sed -rn 's#LEN: (.*)#\1#p' <<< "$tmp"`
-	local off=`sed -rn 's#OFF: (.*)#\1#p' <<< "$tmp"`
+	local tmp=$(fit_info -f "$FIT" -n "$node" -p "$prop")
+	local len=$(sed -rn 's#LEN: (.*)#\1#p' <<< "$tmp")
+	local off=$(sed -rn 's#OFF: (.*)#\1#p' <<< "$tmp")
 	[[ -n "$len" && -n "$off" ]] || return 1
 	#dd if=$FIT skip=$off count=$len iflag=skip_bytes,count_bytes 2>/dev/null
-	tail -c +$((off + 1)) $FIT 2>/dev/null | head -c $len 2>/dev/null
+	tail -c +$((off + 1)) "$FIT" 2>/dev/null | head -c "$len" 2>/dev/null
 }
 
 fit_prop_string() {
@@ -125,7 +125,7 @@ fit_prop_string() {
 }
 
 fit_blob_size() {
-	local tmp=`fit_info -f $FIT -n /images/$1 -p data`
+	local tmp=$(fit_info -f "$FIT" -n "/images/$1" -p data)
 	sed -rn 's#LEN: (.*)#\1#p' <<< "$tmp"
 }
 
@@ -139,18 +139,18 @@ fit_blob_hash() {
 
 fit_blob_verify_hash() {
 	local name=$1
-	local sha1_expected=`fit_blob_hash $name`
+	local sha1_expected=$(fit_blob_hash "$name")
 
 	info "Checking SHA1 hash of $name"
 
-	local blob_size=`fit_blob_size rootfs`
-	local tmp=`mktemp -p $TMPDIR`
+	local blob_size=$(fit_blob_size rootfs)
+	local tmp=$(mktemp -p "$TMPDIR")
 	(
 		echo 0
-		fit_blob_data $name | pv -n -s "$blob_size" | sha1sum | cut -f1 -d' ' > $tmp
+		fit_blob_data "$name" | pv -n -s "$blob_size" | sha1sum | cut -f1 -d' ' > "$tmp"
 	) 2>&1 | mqtt_progress "$x"
-	local sha1_calculated=`cat $tmp`
-	rm $tmp
+	local sha1_calculated=$(cat "$tmp")
+	rm "$tmp"
 
 	[[ "$sha1_expected" == "$sha1_calculated" ]] &&
 		info "SHA1 hash of $name ok" ||
@@ -282,7 +282,7 @@ if [[ ${#ARGS[@]} -ne 1 ]]; then
 	die "Bad arguments"
 fi
 
-FIT=`readlink -f ${ARGS[0]}`
+FIT=$(readlink -f "${ARGS[0]}")
 
 [[ -f "$FIT" ]] || die "FIT $FIT not found"
 
@@ -308,7 +308,7 @@ led_process
 
 >&2 cat <<EOF
 ===============================================================================
-`date`: started update from $FIT
+$(date): started update from $FIT
 ===============================================================================
 Description:         $(fit_prop_string / description)
 Compatible device:   $(fit_prop_string / compatible)
@@ -359,10 +359,11 @@ fi
 check_firmware_compatible
 
 info "Extracting install script (install_update.sh) from FIT"
-INSTALL_SCRIPT=`mktemp -p $TMPDIR`
+INSTALL_SCRIPT=$(mktemp -p $TMPDIR)
 fit_blob_data install > "$INSTALL_SCRIPT" || die
 
 info "Running install script"
+# shellcheck source=utils/lib/wb-image-update/fit/install_update.sh
 source "$INSTALL_SCRIPT"
 
 rm -f "$INSTALL_SCRIPT"

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -197,6 +197,10 @@ check_firmware_compatible() {
         die "Firmware is not compatible with single-rootfs layout"
     fi
 
+    if disk_layout_is_extended && ! fw_compatible "extended-rootfs"; then
+        die "Firmware is not compatible with extended-rootfs layout"
+    fi
+
     info "Firmware seems to be compatible with this controller"
 }
 

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -238,7 +238,7 @@ flag_set no-mqtt && {
 
 
            If you want to perform a regular firmware update, rename
-         FIT file to "wbX_update.fit" without "factory-reset" suffix.
+         FIT file to "wbX_update.fit" without "_FACTORYRESET" suffix.
 
 ##############################################################################
 EOF
@@ -284,7 +284,10 @@ flag_set no-mqtt && {
 	# check factory reset condition here and add flag in this case
 	case $FIT in
 		*FACTORYRESET*|*factoryreset*)
-			if flag_set no-confirm || prompt_update_factoryreset; then
+			if flag_set no-confirm; then
+				echo -e "\nFactory reset (confirm is not required)!\n"
+				FLAGS+="--factoryreset "
+			elif prompt_update_factoryreset; then
 				echo -e "\nFactory reset is confirmed!\n"
 				FLAGS+="--factoryreset "
 			else

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -14,8 +14,10 @@ TMPDIR="/dev/shm"
 FIT=""
 FLAGS=""
 
+EMMC="/dev/mmcblk0"
 # for factory reset
-DATA_PART="/dev/mmcblk0p6"
+ROOT_PART="${EMMC}p2"
+DATA_PART="${EMMC}p6"
 FACTORY_FIT_DIR="/mnt/data/.wb-restore"
 FACTORY_FIT="${FACTORY_FIT_DIR}/factoryreset.fit"
 
@@ -76,7 +78,6 @@ led_prompt() {
 	led red delay_on 100
 	led red delay_off 100
 }
-
 
 mkfs_ext4() {
 	local part=$1
@@ -156,8 +157,8 @@ fit_blob_verify_hash() {
 }
 
 disk_layout_is_ab() {
-    local ROOTFS1_PART=/dev/mmcblk0p2
-    local ROOTFS2_PART=/dev/mmcblk0p3
+    local ROOTFS1_PART="${EMMC}p2"
+    local ROOTFS2_PART="${EMMC}p3"
     [ "$(blockdev --getsz "$ROOTFS1_PART")" -eq "$(blockdev --getsz "$ROOTFS2_PART")" ]
 }
 
@@ -198,6 +199,8 @@ check_firmware_compatible() {
 
     info "Firmware seems to be compatible with this controller"
 }
+
+#---------------------------------------- main ----------------------------------------
 
 [[ $EUID != 0 ]] && die "Need root privileges to install update"
 
@@ -314,7 +317,13 @@ if flag_set factoryreset; then
 
             mkdir -p /mnt
             mkdir -p /mnt/data
-            mount -t auto $DATA_PART /mnt/data || true
+            if [[ -b "$DATA_PART" ]]; then
+                mount -t auto $DATA_PART /mnt/data || true
+            else
+                mkdir -p /mnt/rootfs
+                mount -t auto "${ROOT_PART}" /mnt/rootfs || true
+                mount --bind /mnt/rootfs/mnt/data /mnt/data || true
+            fi
 
             rm -rf /tmp/empty && mkdir /tmp/empty
             rsync -a --delete --exclude="/.wb-restore/" /tmp/empty/ /mnt/data/
@@ -332,7 +341,7 @@ fi
 
 check_firmware_compatible
 
-info "Extracting install script"
+info "Extracting install script (install_update.sh) from FIT"
 INSTALL_SCRIPT=`mktemp -p $TMPDIR`
 fit_blob_data install > "$INSTALL_SCRIPT" || die
 

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -36,7 +36,9 @@ rm_fit() {
 		chattr -i "$FIT"
 		rm -f "$FIT"
 		sync
-		[[ -n "$was_immutable" ]] && chattr +i $FACTORY_FIT || true
+		if [[ -n "$was_immutable" ]]; then
+			chattr +i $FACTORY_FIT || true
+		fi
 	else
 		rm -f "$FIT"
 	fi

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -37,7 +37,7 @@ rm_fit() {
 		rm -f "$FIT"
 		sync
 		if [[ -n "$was_immutable" ]]; then
-			chattr +i $FACTORY_FIT || true
+			chattr +i $FACTORY_FIT || info "WARNING: failed to set immutable attribute on $FACTORY_FIT"
 		fi
 	else
 		rm -f "$FIT"

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -35,7 +35,8 @@ rm_fit() {
 		chattr -i $FIT
 		rm -f "$FIT"
 		sync
-		[[ -n "$was_immutable" ]] && chattr +i $FACTORY_FIT
+		# FIXME: "!!! Error at line 1361 ([[ -n "$was_immutable" ]])"
+		#[[ -n "$was_immutable" ]] && chattr +i $FACTORY_FIT
 	else
 		rm -f "$FIT"
 	fi

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -35,7 +35,7 @@ rm_fit() {
 		chattr -i $FIT
 		rm -f "$FIT"
 		sync
-		[[ -n "$was_immutable" ]] && chattr +i $FACTORY_FIT
+		[[ -n "$was_immutable" ]] && chattr +i $FACTORY_FIT || true
 	else
 		rm -f "$FIT"
 	fi

--- a/utils/bin/wb-watch-update
+++ b/utils/bin/wb-watch-update
@@ -185,7 +185,7 @@ while read EVENT_DIR EVENT_TYPE EVENT_FILE; do
             webupd_fit_file="webupd.fit"
             FIT="${EVENT_DIR}${webupd_fit_file}"
             EVENT_FILE="$webupd_fit_file"
-            was_immutable=$(lsattr -l $WB_FACTORY_FIT | grep "Immutable" || true)
+            local was_immutable=$(lsattr -l $WB_FACTORY_FIT | grep "Immutable" || true)
             chattr -i $WB_FACTORY_FIT
             ln "$WB_FACTORY_FIT" "$FIT"  # uboot has hardcoded webupd fit name
             sync

--- a/utils/bin/wb-watch-update
+++ b/utils/bin/wb-watch-update
@@ -185,7 +185,7 @@ while read EVENT_DIR EVENT_TYPE EVENT_FILE; do
             webupd_fit_file="webupd.fit"
             FIT="${EVENT_DIR}${webupd_fit_file}"
             EVENT_FILE="$webupd_fit_file"
-            local was_immutable=$(lsattr -l $WB_FACTORY_FIT | grep "Immutable" || true)
+            was_immutable=$(lsattr -l $WB_FACTORY_FIT | grep "Immutable" || true)
             chattr -i $WB_FACTORY_FIT
             ln "$WB_FACTORY_FIT" "$FIT"  # uboot has hardcoded webupd fit name
             sync

--- a/utils/lib/wb-image-update/fit/build.sh
+++ b/utils/lib/wb-image-update/fit/build.sh
@@ -86,6 +86,7 @@ cp /usr/lib/wb-image-update/fit/install_update.sh $IMAGEUPDATE_DIR/install_updat
 cd "$BUILDDIR" && tar cvzf $IMAGEUPDATE_DIR/deps.tar.gz .
 
 {
+    echo -n "+extended-rootfs "
     echo -n "+single-rootfs "
     echo -n "+fit-factory-reset "
     echo -n "+force-repartition "

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -418,6 +418,7 @@ ensure_extended_rootfs_parttable() {
             ;;
         *)
             info "Unknown emmc size: $emmc_size bytes"
+            return 1
             ;;
     esac
 

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -1330,7 +1330,7 @@ if ! flag_set from-initramfs && flag_set "force-repartition"; then
     update_after_reboot
 fi
 
-if ( ( flag_set "factoryreset" || flag_set "force-repartition" ) && ! flag_set "no-repartition" ); then
+if ( ( flag_set "factoryreset" || flag_set "force-repartition" ) && ! flag_set "no-repartition" && ! disk_layout_is_extended); then
     maybe_repartition
 fi
 

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -743,7 +743,7 @@ maybe_update_current_factory_tmpfs_size_fix() {
     if ((MEMSIZE_MB<1024)); then
 
         local mnt prefix factory_fit
-        set -- "$(mount_data_dir)" || fatal "Unable to mount data partition"
+        set -- $(mount_data_dir) || fatal "Unable to mount data partition"
         mnt=$1
         prefix=$2
         factory_fit="$mnt$prefix.wb-restore/factoryreset.fit"
@@ -937,11 +937,10 @@ copy_this_fit_to_factory() {
     info "Copying $FIT to factory default location as requested"
 
     local mnt prefix factory_fit
-    set -- "$(mount_data_dir)" || fatal "Unable to mount data partition"
+    set -- $(mount_data_dir) || fatal "Unable to mount data partition"
     mnt=$1
     prefix=$2
     factory_fit="$mnt$prefix.wb-restore/factoryreset.fit"
-    info "mnt=$mnt,prefix=$prefix,factory_fit=$factory_fit"
 
     if FIT="$factory_fit" fw_compatible "fit-immutable-support"; then
         info "Saving immutability state of $factory_fit"
@@ -961,7 +960,7 @@ copy_this_fit_to_factory() {
 update_current_factory_fit_if_not_compatible() {
     local fit_compat_features=$1
     local mnt prefix factory_fit
-    set -- "$(mount_data_dir)" || fatal "Unable to mount data partition"
+    set -- $(mount_data_dir) || fatal "Unable to mount data partition"
     mnt=$1
     prefix=$2
 
@@ -1004,7 +1003,7 @@ update_current_factory_fit_if_not_compatible() {
 
 maybe_trigger_original_factory_fit_to_restore_ab() {
     local mnt prefix original_factory_fit
-    set -- "$(mount_data_dir)" || fatal "Unable to mount data partition"
+    set -- $(mount_data_dir) || fatal "Unable to mount data partition"
     mnt=$1
     prefix=$2
 

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -422,6 +422,10 @@ ensure_extended_rootfs_parttable() {
             ;;
     esac
 
+    umount "$ROOTFS1_PART" >/dev/null 2>&1 || true
+    umount "$ROOTFS2_PART" >/dev/null 2>&1 || true
+    umount "$DATA_PART" >/dev/null 2>&1 || true
+
     sfdisk --dump "$ROOTDEV" | \
         sfdisk_set_size  "$EXT_ROOTFS_PART" "$ROOTFS_SIZE_BLOCKS" | \
         sfdisk_rm_partition "$SWAP_PART" | \

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -304,7 +304,7 @@ sfdisk_set_start() {
 }
 
 sfdisk_set_type() {
-    sed "s#^\\($1.*type=)[0-9]\\+#\\1$2#"
+    sed "s#^\\($1.*type=\\)[0-9]\\+#\\1$2#"
 }
 
 sfdisk_rm_partition() {

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -407,20 +407,14 @@ ensure_extended_rootfs_parttable() {
     case "$((emmc_size / 1024 / 1024 / 1024))" in
         7)
             info "8G emmc"
-            ROOTFS_SIZE_BLOCKS=13137920
-            SWAP_START_BLOCKS=13172736
             RESERVED_START_BLOCKS=14221312
             ;;
         14)
             info "16G emmc"
-            ROOTFS_SIZE_BLOCKS=29915136
-            SWAP_START_BLOCKS=29949952
             RESERVED_START_BLOCKS=30998528
             ;;
         58)
             info "64G emmc"
-            ROOTFS_SIZE_BLOCKS=130578432
-            SWAP_START_BLOCKS=130613248
             RESERVED_START_BLOCKS=131661824
             ;;
         *)
@@ -428,6 +422,9 @@ ensure_extended_rootfs_parttable() {
             return 1
             ;;
     esac
+
+    SWAP_START_BLOCKS=$(( RESERVED_START_BLOCKS - SWAP_SIZE_BLOCKS ))
+    ROOTFS_SIZE_BLOCKS=$(( SWAP_START_BLOCKS - ROOTFS_START_BLOCKS ))
 
     info "Umount partitions"
     umount "$ROOTFS1_PART" >/dev/null 2>&1 || true

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -424,14 +424,14 @@ ensure_extended_rootfs_parttable() {
 
     sfdisk --dump "$ROOTDEV" | \
         sfdisk_set_size  "$EXT_ROOTFS_PART" "$ROOTFS_SIZE_BLOCKS" | \
+        sfdisk_rm_partition "$SWAP_PART" | \
+        sfdisk_rm_partition "$DATA_PART" | \
         sfdisk_set_start "$EXT_SWAP_PART" "$SWAP_START_BLOCKS" | \
         sfdisk_set_size "$EXT_SWAP_PART" "$SWAP_SIZE_BLOCKS" | \
         sfdisk_set_type "$EXT_SWAP_PART" 82 | \
         sfdisk_set_start "$EXT_RESERVED_PART" "$RESERVED_START_BLOCKS" | \
         sfdisk_set_size "$EXT_RESERVED_PART" "$RESERVED_SIZE_BLOCKS" | \
         sfdisk_set_type "$EXT_RESERVED_PART" 83 | \
-        sfdisk_rm_partition "$SWAP_PART" | \
-        sfdisk_rm_partition "$DATA_PART" | \
         tee "$TEMP_DUMP" | \
         sfdisk -f "$ROOTDEV" --no-reread >/dev/null || {
 
@@ -794,7 +794,7 @@ maybe_repartition() {
         return
     fi
 
-    if flag_set extend-rootfs; then
+    if flag_set extend-rootfs && ! flag_set from-webupdate && ! flag_set from-emmc-factoryreset; then
         info "Extending rootfs as requested"
         if ! ensure_extended_rootfs_parttable; then
             fatal "Failed to extend rootfs"

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -479,15 +479,15 @@ ensure_extended_rootfs_parttable() {
         fatal "Failed to create filesystem on new swap, exiting"
     }
 
-    info "Creating filesystem on reserved partition"
-    mkfs_ext4 "$EXT_RESERVED_PART" "reserved" || {
-        info "Creating new filesystem on reserved partition failed!"
-        info "Restoring saved MBR backup and exit"
-        dd if="$mbr_backup" of="$ROOTDEV" oflag=direct conv=notrunc || true
-        sync
-        reload_parttable
-        fatal "Failed to create filesystem on new reserved, exiting"
-    }
+    #info "Creating filesystem on reserved partition"
+    #mkfs_ext4 "$EXT_RESERVED_PART" "reserved" || {
+    #    info "Creating new filesystem on reserved partition failed!"
+    #    info "Restoring saved MBR backup and exit"
+    #    dd if="$mbr_backup" of="$ROOTDEV" oflag=direct conv=notrunc || true
+    #    sync
+    #    reload_parttable
+    #    fatal "Failed to create filesystem on new reserved, exiting"
+    #}
 
     info "Repartition is done!"
 }

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -944,7 +944,7 @@ copy_this_fit_to_factory() {
         local was_immutable=$(lsattr -l $factory_fit | grep "Immutable" || true)
         chattr -i $factory_fit
         cp "$FIT" "$factory_fit"
-        [[ -n "$was_immutable" ]] && chattr +i $factory_fit
+        [[ -n "$was_immutable" ]] && chattr +i $factory_fit || true
     else  # no chattr / lsattr in factory fit
         cp "$FIT" "$factory_fit"
     fi

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -453,6 +453,7 @@ ensure_extended_rootfs_parttable() {
         return 1
     }
 
+    cat "$TEMP_DUMP"
     sync
     reload_parttable
 
@@ -485,6 +486,7 @@ ensure_extended_rootfs_parttable() {
         restore_mbr "$mbr_backup"
         fatal "Failed to create filesystem on new reserved, exiting"
     }
+    mmc writeprotect user set temp $RESERVED_START_BLOCKS $RESERVED_SIZE_BLOCKS $ROOTDEV
 
     info "Repartition is done!"
 }

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -339,7 +339,7 @@ run_e2fsck() {
 }
 
 ensure_extended_rootfs_parttable() {
-    if ! disk_layout_is_extended; then
+    if disk_layout_is_extended; then
         info "Partition table seems to be changed already, continue"
         return 0
     fi

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -1172,6 +1172,10 @@ check_firmware_compatible() {
         fatal "Firmware is not compatible with this device, no proper DTB found"
     fi
 
+    if disk_layout_is_extended && ! fw_compatible "extended-rootfs"; then
+        die "Firmware is not compatible with extended-rootfs layout"
+    fi
+
     info "Firmware seems to be compatible with this controller"
 }
 

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -396,21 +396,28 @@ ensure_extended_rootfs_parttable() {
     SWAP_SIZE_BLOCKS=1048576
     RESERVED_SIZE_BLOCKS=1048576
 
-    case "$(blockdev --getsz $ROOTDEV)" in
+    local emmc_size=$(blockdev --getsz $ROOTDEV)
+    case "$emmc_size" in
         15269888) # 8G
+            info "8G emmc"
             ROOTFS_SIZE_BLOCKS=13137920
             SWAP_START_BLOCKS=13172736
             RESERVED_START_BLOCKS=14221312
             ;;
         30535680) # 16G
+            info "16G emmc"
             ROOTFS_SIZE_BLOCKS=29915136
             SWAP_START_BLOCKS=29949952
             RESERVED_START_BLOCKS=30998528
             ;;
         122142720) # 64G
+            info "64G emmc"
             ROOTFS_SIZE_BLOCKS=130578432
             SWAP_START_BLOCKS=130613248
             RESERVED_START_BLOCKS=131661824
+            ;;
+        *)
+            info "Unknown emmc size: $emmc_size"
             ;;
     esac
 

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -950,7 +950,7 @@ copy_this_fit_to_factory() {
         chattr -i "$factory_fit"
         cp "$FIT" "$factory_fit"
         if [[ -n "$was_immutable" ]]; then
-            chattr +i "$factory_fit" || true
+            chattr +i "$factory_fit" || info "WARNING: failed to set immutable attribute on $factory_fit"
         fi
     else  # no chattr / lsattr in factory fit
         cp "$FIT" "$factory_fit"

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -1172,10 +1172,6 @@ check_firmware_compatible() {
         fatal "Firmware is not compatible with this device, no proper DTB found"
     fi
 
-    if disk_layout_is_extended && ! fw_compatible "extended-rootfs"; then
-        die "Firmware is not compatible with extended-rootfs layout"
-    fi
-
     info "Firmware seems to be compatible with this controller"
 }
 

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -941,6 +941,7 @@ copy_this_fit_to_factory() {
     mnt=$1
     prefix=$2
     factory_fit="$mnt$prefix.wb-restore/factoryreset.fit"
+    info "mnt=$mnt,prefix=$prefix,factory_fit=$factory_fit"
 
     if FIT="$factory_fit" fw_compatible "fit-immutable-support"; then
         info "Saving immutability state of $factory_fit"

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -977,6 +977,9 @@ update_current_factory_fit_if_not_compatible() {
         info "No factory FIT found, storing this update as factory FIT to use as bootlet"
         mkdir -p "$wb_restore_dir"
         cp "$FIT" "$factory_fit"
+        if FIT="$factory_fit" fw_compatible "fit-immutable-support"; then
+            chattr +i "$factory_fit" || info "WARNING: failed to set immutable attribute on $factory_fit"
+        fi
         umount "$mnt" || true
         sync
         return

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -476,14 +476,15 @@ ensure_extended_rootfs_parttable() {
         fatal "Failed to create filesystem on new swap, exiting"
     }
 
-    info "Creating filesystem on reserved partition"
-    mkfs_ext4 "$EXT_RESERVED_PART" "reserved" || {
-        info "Creating new filesystem on reserved partition failed!"
-        info "Restoring saved MBR backup and exit"
-        restore_mbr "$mbr_backup"
-        fatal "Failed to create filesystem on new reserved, exiting"
-    }
-    mmc writeprotect user set temp $RESERVED_START_BLOCKS $RESERVED_SIZE_BLOCKS $ROOTDEV
+    # FIXME: Buffer I/O error
+    #info "Creating filesystem on reserved partition"
+    #mkfs_ext4 "$EXT_RESERVED_PART" "reserved" || {
+    #    info "Creating new filesystem on reserved partition failed!"
+    #    info "Restoring saved MBR backup and exit"
+    #    restore_mbr "$mbr_backup"
+    #    fatal "Failed to create filesystem on new reserved, exiting"
+    #}
+    #mmc writeprotect user set temp $RESERVED_START_BLOCKS $RESERVED_SIZE_BLOCKS $ROOTDEV
 
     info "Repartition is done!"
 }

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -743,6 +743,7 @@ maybe_update_current_factory_tmpfs_size_fix() {
     if ((MEMSIZE_MB<1024)); then
 
         local mnt prefix factory_fit
+        # shellcheck disable=SC2046
         set -- $(mount_data_dir) || fatal "Unable to mount data partition"
         mnt=$1
         prefix=$2
@@ -937,6 +938,7 @@ copy_this_fit_to_factory() {
     info "Copying $FIT to factory default location as requested"
 
     local mnt prefix factory_fit
+    # shellcheck disable=SC2046
     set -- $(mount_data_dir) || fatal "Unable to mount data partition"
     mnt=$1
     prefix=$2
@@ -960,6 +962,7 @@ copy_this_fit_to_factory() {
 update_current_factory_fit_if_not_compatible() {
     local fit_compat_features=$1
     local mnt prefix factory_fit
+    # shellcheck disable=SC2046
     set -- $(mount_data_dir) || fatal "Unable to mount data partition"
     mnt=$1
     prefix=$2
@@ -1003,6 +1006,7 @@ update_current_factory_fit_if_not_compatible() {
 
 maybe_trigger_original_factory_fit_to_restore_ab() {
     local mnt prefix original_factory_fit
+    # shellcheck disable=SC2046
     set -- $(mount_data_dir) || fatal "Unable to mount data partition"
     mnt=$1
     prefix=$2

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -478,13 +478,13 @@ ensure_extended_rootfs_parttable() {
         fatal "Failed to create filesystem on new swap, exiting"
     }
 
-    #info "Creating filesystem on reserved partition"
-    #mkfs_ext4 "$EXT_RESERVED_PART" "reserved" || {
-    #    info "Creating new filesystem on reserved partition failed!"
-    #    info "Restoring saved MBR backup and exit"
-    #    restore_mbr "$mbr_backup"
-    #    fatal "Failed to create filesystem on new reserved, exiting"
-    #}
+    info "Creating filesystem on reserved partition"
+    mkfs_ext4 "$EXT_RESERVED_PART" "reserved" || {
+        info "Creating new filesystem on reserved partition failed!"
+        info "Restoring saved MBR backup and exit"
+        restore_mbr "$mbr_backup"
+        fatal "Failed to create filesystem on new reserved, exiting"
+    }
 
     info "Repartition is done!"
 }

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -403,26 +403,11 @@ ensure_extended_rootfs_parttable() {
     SWAP_SIZE_BLOCKS=1048576
     RESERVED_SIZE_BLOCKS=1048576
 
+    local block_size=512
     local emmc_size=$(blockdev --getsize64 $ROOTDEV)
-    case "$((emmc_size / 1024 / 1024 / 1024))" in
-        7)
-            info "8G emmc"
-            RESERVED_START_BLOCKS=14221312
-            ;;
-        14)
-            info "16G emmc"
-            RESERVED_START_BLOCKS=30998528
-            ;;
-        58)
-            info "64G emmc"
-            RESERVED_START_BLOCKS=131661824
-            ;;
-        *)
-            info "Unknown emmc size: $emmc_size bytes"
-            return 1
-            ;;
-    esac
+    local write_protect_group_size=$(( 8*1024*1024 ))
 
+    RESERVED_START_BLOCKS=$(( ((emmc_size / write_protect_group_size) * write_protect_group_size)/block_size - RESERVED_SIZE_BLOCKS ))
     SWAP_START_BLOCKS=$(( RESERVED_START_BLOCKS - SWAP_SIZE_BLOCKS ))
     ROOTFS_SIZE_BLOCKS=$(( SWAP_START_BLOCKS - ROOTFS_START_BLOCKS ))
 

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -304,7 +304,7 @@ sfdisk_set_start() {
 }
 
 sfdisk_set_type() {
-    sed "s#^\\($1.*type=\\s\\+\\)[0-9]\\+\\(.*\\)#\\1 $2\\2#"
+    sed "s#^\\($1.*type=)[0-9]\\+#\\1$2#"
 }
 
 sfdisk_rm_partition() {
@@ -422,6 +422,7 @@ ensure_extended_rootfs_parttable() {
             ;;
     esac
 
+    info "Umount partitions"
     umount "$ROOTFS1_PART" >/dev/null 2>&1 || true
     umount "$ROOTFS2_PART" >/dev/null 2>&1 || true
     umount "$DATA_PART" >/dev/null 2>&1 || true

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -396,28 +396,28 @@ ensure_extended_rootfs_parttable() {
     SWAP_SIZE_BLOCKS=1048576
     RESERVED_SIZE_BLOCKS=1048576
 
-    local emmc_size=$(blockdev --getsz $ROOTDEV)
-    case "$emmc_size" in
-        15269888) # 8G
+    local emmc_size=$(blockdev --getsize64 $ROOTDEV)
+    case "$((emmc_size / 1024 / 1024 / 1024))" in
+        7)
             info "8G emmc"
             ROOTFS_SIZE_BLOCKS=13137920
             SWAP_START_BLOCKS=13172736
             RESERVED_START_BLOCKS=14221312
             ;;
-        30535680) # 16G
+        14)
             info "16G emmc"
             ROOTFS_SIZE_BLOCKS=29915136
             SWAP_START_BLOCKS=29949952
             RESERVED_START_BLOCKS=30998528
             ;;
-        122142720) # 64G
+        58)
             info "64G emmc"
             ROOTFS_SIZE_BLOCKS=130578432
             SWAP_START_BLOCKS=130613248
             RESERVED_START_BLOCKS=131661824
             ;;
         *)
-            info "Unknown emmc size: $emmc_size"
+            info "Unknown emmc size: $emmc_size bytes"
             ;;
     esac
 

--- a/utils/lib/wb-image-update/fix-broken-fit.sh
+++ b/utils/lib/wb-image-update/fix-broken-fit.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+# shellcheck source=utils/lib/wb_env.sh
 . /usr/lib/wb-utils/wb_env.sh
 wb_source "of"
 
@@ -38,7 +39,9 @@ if of_machine_match "wirenboard,wirenboard-7xx" || of_machine_match "wirenboard,
                     chattr -i $FACTORYRESET_FIT
                     mv "${FACTORYRESET_FIT}.new" "$FACTORYRESET_FIT"
                     sync
-                    [[ -n "$was_immutable" ]] && chattr +i $FACTORYRESET_FIT || true
+                    if [[ -n "$was_immutable" ]]; then
+                        chattr +i "$FACTORYRESET_FIT" || true
+                    fi
                     break
                 fi
             done

--- a/utils/lib/wb-image-update/fix-broken-fit.sh
+++ b/utils/lib/wb-image-update/fix-broken-fit.sh
@@ -39,9 +39,7 @@ if of_machine_match "wirenboard,wirenboard-7xx" || of_machine_match "wirenboard,
                     chattr -i $FACTORYRESET_FIT
                     mv "${FACTORYRESET_FIT}.new" "$FACTORYRESET_FIT"
                     sync
-                    if [[ -n "$was_immutable" ]]; then
-                        chattr +i "$FACTORYRESET_FIT" || true
-                    fi
+                    [[ -n "$was_immutable" ]] && chattr +i $FACTORYRESET_FIT
                     break
                 fi
             done

--- a/utils/lib/wb-image-update/fix-broken-fit.sh
+++ b/utils/lib/wb-image-update/fix-broken-fit.sh
@@ -38,7 +38,7 @@ if of_machine_match "wirenboard,wirenboard-7xx" || of_machine_match "wirenboard,
                     chattr -i $FACTORYRESET_FIT
                     mv "${FACTORYRESET_FIT}.new" "$FACTORYRESET_FIT"
                     sync
-                    [[ -n "$was_immutable" ]] && chattr +i $FACTORYRESET_FIT
+                    [[ -n "$was_immutable" ]] && chattr +i $FACTORYRESET_FIT || true
                     break
                 fi
             done

--- a/utils/lib/wb-image-update/postinst/20fstab-extended
+++ b/utils/lib/wb-image-update/postinst/20fstab-extended
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+
+# Called from install_update.sh with arguments
+# /path/to/script /path/to/new/rootfs [flag1 [flag2 ...]]
+#
+# This script may run in Busybox initramfs environment,
+# so if you need some special tools or features, use ones from rootfs.
+#
+# /dev, /proc and /sys are already bind-mounted
+# from host system to rootfs tree.
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 path/to/rootfs [flag1 [flag2 ...]]"
+    exit 2
+fi
+
+ROOTFS="$1"
+DATA_PART="/dev/mmcblk0p6"
+
+if [[ ! -b "DATA_PART" ]]; then
+    cp "$ROOTFS/etc/fstab.extended.wb" "$ROOTFS/etc/fstab"
+fi

--- a/utils/lib/wb-image-update/postinst/20fstab-extended
+++ b/utils/lib/wb-image-update/postinst/20fstab-extended
@@ -17,6 +17,6 @@ fi
 ROOTFS="$1"
 DATA_PART="/dev/mmcblk0p6"
 
-if [[ ! -b "DATA_PART" ]]; then
+if [[ ! -b "$DATA_PART" ]]; then
     cp "$ROOTFS/etc/fstab.extended.wb" "$ROOTFS/etc/fstab"
 fi


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Поддержка новой схемы
Rework https://github.com/wirenboard/wb-utils/pull/170

Поддерживаемые способы обновления:
* с помощью USB-флешки или карты Micro-SD
* через Debug Network

По дефолту расширения не происходит, только c явной опцией:
```sh
cp *.fit /mnt/sdcard/wb_update_FACTORYRESET.fit
echo "--extend-rootfs" > /mnt/sdcard/install_update.flags
```

Откат к старой схеме не предусмотрен.
___________________________________
**Что поменялось для пользователей:**
Схлапывание rootfs и data разделов

___________________________________
**Как проверял/а:**
Фиты:
* https://jenkins.wirenboard.com/view/pipelines/job/pipelines/job/build-image/12137/artifact/jenkins_output/202509301435_testing_bullseye_wb67.fit
* https://jenkins.wirenboard.com/view/pipelines/job/pipelines/job/build-image/12136/artifact/jenkins_output/202509301435_testing_bullseye_wb7x.fit
* https://jenkins.wirenboard.com/view/pipelines/job/pipelines/job/build-image/12135/artifact/jenkins_output/202509301435_testing_bullseye_wb8x.fit

Конфигурации:
* [ ] wb67, 8G emmc, FR from USB-flash => FR from emmc => FR with wb-factoryreset
* [x] wb7, 8G emmc, FR from USB-flash => FR from emmc => FR with wb-factoryreset
* [ ] wb7, 64G emmc, FR from USB-flash => FR from emmc => FR with wb-factoryreset
* [ ] wb8, 16G emmc, FR from USB-flash => FR from emmc => FR with wb-factoryreset
* [x] wb8, 64G emmc, FR from USB-flash => FR from emmc => FR with wb-factoryreset

### Как откатится к старой схеме вручную, если что-то пошло не так
1. грузимся с recovery microsd (emmc доступна как `/dev/sda*` на втором контроллере к которому подключен debug network от первого)
2. откатываем схему:
```sh
sfdisk --dump /dev/mmcblk0 | sfdisk -f /dev/sda --no-reread  # при условии что оба контроллера одинаковые по размеру emmc
yes | mkfs.ext4 -L "rootfs" -E stride=2,stripe-width=1024 -b 4096 /dev/sda2
yes | mkfs.ext4 -L "rootfs2" -E stride=2,stripe-width=1024 -b 4096 /dev/sda3
mkswap /dev/sda5
yes | mkfs.ext4 -L "data" -E stride=2,stripe-width=1024 -b 4096 /dev/sda6
```
3. восстанавливаем рутфс:
```sh
wget https://fw-releases.wirenboard.com/fit_image/testing/7x/latest.fit  # либо 8x
dumpimage -T flat_dt -p 3 -o ~/rootfs.tar.gz ./latest.fit
mount /dev/sda2 /mnt/sdcard
pushd /mnt/sdcard
cat ~/rootfs.tar.gz | tar xzp
dd bs=1024 seek=8 if=./usr/lib/u-boot/sun8i_wirenboard7/u-boot-sunxi-with-spl.bin of=/dev/sda oflag=direct conv=notrunc
popd
umount /mnt/sdcard
mount /dev/sda6 /mnt/sdcard
pushd /mnt/sdcard
mkdir -p .wb-restore .wb-update
cp ~/latest.fit .wb-restore/factoryreset.fit
chattr +i .wb-restore/factoryreset.fit
popd
umount /mnt/sdcard
```
4. делаем FR

### Как грузится в бутлет
* wb7
```sh
=> setenv bootargs console=${console} bootmode=debug_console
=> load mmc 1:2 0x42000000 /var/lib/wb-image-update/zImage
=> load mmc 1:2 0x43000000 /boot/dtbs/sun8i-r40-wirenboard733.dtb
=> bootz 0x42000000 - 0x43000000
```

### Как пересобрать фит
1. пушим `feature/SOFT-4833` ветку в wb-utils, ждем пока заедет в тестинг сет `extended-rootfs`
2. пересобираем `feature/SOFT-4833` ветку в wb-initramfs
3. пересобираем бутлеты из веток `feature/SOFT-4833` и `feature/SOFT-4833-wb8` в ядре, ждем пока бутлеты заедут в тестинг сет
4. собираем фит с `ADDITIONAL_REPOS=http://deb.wirenboard.com/all@experimental.extended-rootfs:main`