### PR TITLE
Fix/soft 6093 immutable files

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,12 @@
+wb-utils (4.27.1) stable; urgency=medium
+
+  * Add attempt to reset immutable attributes for roots files if wipe data routine failed
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Fri, 17 Oct 2025 11:57:04 +0300
+
 wb-utils (4.27.0) stable; urgency=medium
 
-  * add extended rootfs support
+  * Add extended rootfs support
 
  -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 23 Jul 2025 15:10:00 +0400
 
@@ -158,7 +164,7 @@ wb-utils (4.19.3) stable; urgency=medium
 
 wb-utils (4.19.2) stable; urgency=medium
 
-  * Fix rootfs extending on 512M RAM 
+  * Fix rootfs extending on 512M RAM
 
  -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Mon, 20 Nov 2023 18:36:15 +0300
 

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -651,7 +651,7 @@ ensure_ab_rootfs_parttable() {
 
 reset_immutable()
 {
-    local list="/mnt/data/.wb-restore /mnt/data/.wb-update /mtn/sdcard /mtn/rootfs/dev"
+    local list="/mnt/data/.wb-restore /mnt/data/.wb-update /mnt/sdcard /mnt/rootfs/dev"
     local exclude
     local or
 
@@ -661,7 +661,7 @@ reset_immutable()
     done
 
     info "Trying to reset immutable attributes for files..."
-    find /mnt/ \( $exclude \) -prune -o -type f -print0 | xargs -0 charrt -i
+    find /mnt/ \( $exclude \) -prune -o -type f -print0 | xargs -0 chattr -i
 }
 
 cleanup_rootfs() {

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -651,7 +651,7 @@ ensure_ab_rootfs_parttable() {
 
 reset_immutable()
 {
-    local exclude="-path /mnt/data/.wb-restore -o -path /mnt/data/.wb-update -o -path /mnt/sdcard /mnt/rootfs/dev"
+    local exclude="-path /mnt/data/.wb-restore -o -path /mnt/data/.wb-update -o -path /mnt/sdcard -o -path /mnt/rootfs/dev"
     info "Trying to reset immutable attributes for files..."
     find /mnt/ \( $exclude \) -prune -o -type f -print0 | xargs -0 chattr -i
 }

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -651,15 +651,7 @@ ensure_ab_rootfs_parttable() {
 
 reset_immutable()
 {
-    local list="/mnt/data/.wb-restore /mnt/data/.wb-update /mnt/sdcard /mnt/rootfs/dev"
-    local exclude
-    local or
-
-    for path in $list; do
-        exclude+="$or-path $path"
-        or=" -o "
-    done
-
+    local exclude="-path /mnt/data/.wb-restore -o -path /mnt/data/.wb-update -o -path /mnt/sdcard /mnt/rootfs/dev"
     info "Trying to reset immutable attributes for files..."
     find /mnt/ \( $exclude \) -prune -o -type f -print0 | xargs -0 chattr -i
 }

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -658,9 +658,10 @@ reset_immutable()
 
 cleanup_rootfs() {
     local ROOT_PART="$1"
-    local mountpoint="$(mktemp -d)"
+    local mountpoint
     local cmd
 
+    mountpoint="$(mktemp -d)"
     mount -t ext4 "$ROOT_PART" "$mountpoint" >/dev/null 2>&1 || fatal "Unable to mount root filesystem"
 
     info "Cleaning up $ROOT_PART"
@@ -1215,12 +1216,12 @@ maybe_factory_reset() {
         local cmd=(rsync -a --delete --exclude="/.wb-restore/" --exclude="/.wb-update/" /tmp/empty/ /mnt/data/)
         "${cmd[@]}" || (reset_immutable && "${cmd[@]}")
 
-        local FACTORY_FIT_DIR="/mnt/data/.wb-restore"
-        local FACTORY_FIT="${FACTORY_FIT_DIR}/factoryreset.fit"
-        if [[ ! -e "$FACTORY_FIT" ]]; then
+        local factory_fit_dir="/mnt/data/.wb-restore"
+        local factory_fit="${factory_fit_dir}/factoryreset.fit"
+        if [[ ! -e "$factory_fit" ]]; then
             echo "Saving current update file as factory default image"
-            mkdir -p "$FACTORY_FIT_DIR"
-            cp "$FIT" "$FACTORY_FIT"
+            mkdir -p "$factory_fit_dir"
+            cp "$FIT" "$factory_fit"
         fi
     else
         fatal "Factory reset is now supported only from initramfs environment"


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Если включить `immutable` атрибут у любого файла в `rootfs`, контроллер становится невозможно прошить, скрипт прошивки ломается на этапе очистки `rootfs` ("wiping data partition").

___________________________________
**Что поменялось для пользователей:**
Теперь, в случае неудачной попытки очистки `rootfs`, скрипт сначала снимает `immutable` атрибут со всех файлов (кроме `/mnt/data/.wb-restore/factoryreset.fit`) и снова пытается очистить `rootfs`.

___________________________________
**Как проверял/а:**
Собрал тестовые фиты, понаделал immutable файлов на контроллере, проверил, что прошивка проходит без сбоев:
```
>>> Trying to reset immutable attributes for files...
```

