### PR TITLE
wb-prepare: generate machine-id at the very end

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.27.2) stable; urgency=medium
+
+  * wb-prepare: generate machine-id at the very end of firstboot
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Tue, 18 Nov 2025 12:51:02 +0300
+
 wb-utils (4.27.1) stable; urgency=medium
 
   * Add attempt to reset immutable attributes for roots files if wipe data routine failed

--- a/utils/lib/prepare/wb-prepare.sh
+++ b/utils/lib/prepare/wb-prepare.sh
@@ -274,7 +274,6 @@ wb_firstboot()
     wb_fix_serial
     wb_fix_macs
     wb_fix_short_sn
-    wb_fix_machine_id
 
     log_action_msg "Generating SSH host keys if necessary"
     for keytype in ecdsa dsa rsa; do
@@ -299,6 +298,8 @@ wb_firstboot()
     sync
 
     wb_run_scripts /etc/wb-prepare.d
+
+    wb_fix_machine_id  # should be at the very end of firstboot to retry on failure
 
     if $FIRSTBOOT_NEED_REBOOT; then
         reboot


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
в тыжпрограммист пришли с хотелкой отслеживать иногда ломающийся firstboot на производстве

я подумал, почему он может ломаться и нашел, что machine-id (маркер firstboot-а) генерируется не в самом конце нашей магии => подвинул в конец
___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
поправил на wb ручками => удалил machine-id => проследил, что firstboot успешен
