### PR TITLE
wb-prepare: generate machine-id at the very end (#180)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.26.2-wb100) stable; urgency=medium
+
+  * wb-prepare: generate machine-id at the very end of firstboot
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Tue, 18 Nov 2025 12:51:02 +0300
+
 wb-utils (4.26.2) stable; urgency=medium
 
   * Auto detect swap partition

--- a/utils/lib/prepare/wb-prepare.sh
+++ b/utils/lib/prepare/wb-prepare.sh
@@ -333,7 +333,6 @@ wb_firstboot()
     wb_fix_serial
     wb_fix_macs
     wb_fix_short_sn
-    wb_fix_machine_id
 
     log_action_msg "Generating SSH host keys if necessary"
     for keytype in ecdsa dsa rsa; do
@@ -358,6 +357,8 @@ wb_firstboot()
     sync
 
     wb_run_scripts /etc/wb-prepare.d
+
+    wb_fix_machine_id  # should be at the very end of firstboot to retry on failure
 
     if $FIRSTBOOT_NEED_REBOOT; then
         reboot


### PR DESCRIPTION
add https://github.com/wirenboard/wb-utils/pull/180/commits to release branch for backporting
___________________________________
**Что происходит; кому и зачем нужно:**

factory reset will be more stable
___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


