### PR TITLE
Add "uboot-dymanic-env" compatibility flag

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.27.2) stable; urgency=medium
+
+  * Update U-Boot ENV routines
+
+ -- Ilya Titov <ilya.titov@wirenboard.com>  Fri, 14 Nov 2025 17:53:11 +0300
+
 wb-utils (4.27.1) stable; urgency=medium
 
   * Add attempt to reset immutable attributes for roots files if wipe data routine failed

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -208,6 +208,10 @@ check_firmware_compatible() {
         die "Firmware is not compatible with extended-rootfs layout"
     fi
 
+    if ! fw_compatible "uboot-dynamic-env"; then
+        fatal "Firmware is not compatible with dynamic U-Boot ENV data location, please use newer one from https://fw-releases.wirenboard.com/"
+    fi
+
     info "Firmware seems to be compatible with this controller"
 }
 

--- a/utils/bin/wb-run-update
+++ b/utils/bin/wb-run-update
@@ -209,7 +209,7 @@ check_firmware_compatible() {
     fi
 
     if ! fw_compatible "uboot-dynamic-env"; then
-        fatal "Firmware is not compatible with dynamic U-Boot ENV data location, please use newer one from https://fw-releases.wirenboard.com/"
+        die "Firmware is not compatible with dynamic U-Boot ENV data location, please use newer one from https://fw-releases.wirenboard.com/"
     fi
 
     info "Firmware seems to be compatible with this controller"

--- a/utils/lib/prepare/wb-prepare.sh
+++ b/utils/lib/prepare/wb-prepare.sh
@@ -217,42 +217,6 @@ wb_run_scripts()
     fi
 }
 
-wb_update_fw_env_config()
-{
-    local config_file="/etc/fw_env.config"
-    local device_name="/dev/mmcblk0"
-    local offset size
-
-    log_action_msg "Reading uboot env offset/size from device tree..."
-
-    if of_has_prop "wirenboard" "uboot-env-offset"; then
-        offset=$(of_get_prop_str "wirenboard" "uboot-env-offset")
-    else
-        log_warning_msg "Could not read uboot-env-offset from device tree. Keeping old fw_env.config from rootfs"
-        return 0
-    fi
-
-    if of_has_prop "wirenboard" "uboot-env-size"; then
-        size=$(of_get_prop_str "wirenboard" "uboot-env-size")
-    else
-        log_warning_msg "Could not read uboot-env-size from device tree. Keeping old fw_env.config from rootfs"
-        return 0
-    fi
-
-    cat > "$config_file" << EOF
-# Configuration file for fw_(printenv/saveenv) utility.
-# Up to two entries are valid, in this case the redundant
-# environment sector is assumed present.
-#
-# XXX this configuration might miss a fifth parameter for the "Number of
-# sectors"
-
-# MTD device name   Device offset   Env. size   Flash sector size
-$device_name        $offset             $size
-EOF
-    log_action_msg "Successfully updated $config_file"
-}
-
 # This function should be called only on first boot of the rootfs
 wb_firstboot()
 {
@@ -309,7 +273,6 @@ wb_firstboot()
 
 case "$1" in
     firstboot)
-        wb_update_fw_env_config
         wb_prepare_filesystems
         wb_firstboot
         exit $?

--- a/utils/lib/wb-image-update/fit/build.sh
+++ b/utils/lib/wb-image-update/fit/build.sh
@@ -94,6 +94,7 @@ cd "$BUILDDIR" && tar cvzf $IMAGEUPDATE_DIR/deps.tar.gz .
     echo -n "+fit-immutable-support "
     echo -n "+wb8-debug-network-update-fix "
     echo -n "+wrong-ab-layout-fix "
+    echo -n "+uboot-dynamic-env "
 } >> $IMAGEUPDATE_DIR/firmware-compatible
 
 if of_machine_match "wirenboard,wirenboard-8xx"; then

--- a/utils/lib/wb-image-update/fit/build.sh
+++ b/utils/lib/wb-image-update/fit/build.sh
@@ -28,7 +28,7 @@ cleanup() {
     rm -rf "$BUILDDIR"
 }
 
-trap cleanup EXIT 
+trap cleanup EXIT
 
 install_dir() {
     echo "dir $1"

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -1336,6 +1336,7 @@ elif flag_set factoryreset; then
 fi
 
 info "Switching to new rootfs"
+info "$(cat /etc/fw_env.config)"
 cp $MNT/etc/fw_env.config /etc/fw_env.config
 fw_setenv mmcpart "$PART"
 fw_setenv upgrade_available 1

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -1282,7 +1282,7 @@ else
 fi
 
 if ! flag_set from-initramfs && flag_set "force-repartition"; then
-    update_current_factory_fit_if_not_compatible "single-rootfs wb8-debug-network-update-fix wrong-ab-layout-fix"
+    update_current_factory_fit_if_not_compatible "single-rootfs wb8-debug-network-update-fix wrong-ab-layout-fix uboot-dynamic-env"
     update_after_reboot
 fi
 
@@ -1332,7 +1332,7 @@ fi
 if flag_set copy-to-factory; then
     copy_this_fit_to_factory
 elif flag_set factoryreset; then
-    update_current_factory_fit_if_not_compatible "single-rootfs wb8-debug-network-update-fix wrong-ab-layout-fix"
+    update_current_factory_fit_if_not_compatible "single-rootfs wb8-debug-network-update-fix wrong-ab-layout-fix uboot-dynamic-env"
 fi
 
 info "Switching to new rootfs"

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -1205,13 +1205,19 @@ maybe_factory_reset() {
         mkdir -p /mnt/data
         if [[ -b "$DATA_PART" ]]; then
             mount -t auto "$DATA_PART" /mnt/data 2>/dev/null || true
+            info "bla"
         else
             mkdir -p /mnt/rootfs
             mount -t auto "$ROOT_PART" /mnt/rootfs || true
             mount --bind /mnt/rootfs/mnt/data /mnt/data || true
+            info "foo"
         fi
 
+        ls -la /mnt/
+
         cp /mnt/rootfs/etc/fw_env.config /etc/fw_env.config || true
+        cat /etc/fw_env.config
+
         rm -rf /tmp/empty && mkdir /tmp/empty
 
         local cmd=(rsync -a --delete --exclude="/.wb-restore/" --exclude="/.wb-update/" /tmp/empty/ /mnt/data/)

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -16,6 +16,9 @@ EXT_ROOTFS_PART=${ROOTDEV}p2
 EXT_SWAP_PART=${ROOTDEV}p3
 EXT_RESERVED_PART=${ROOTDEV}p4
 
+# U-Boot ENV tools config in mounted rootfs
+ROOTFS_ENV_CONF="/mnt/rootfs/etc/fw_env.config"
+
 # appends a command to a trap
 #
 # - 1st arg:  code to add
@@ -700,7 +703,7 @@ check_compatible() {
 
 select_new_partition() {
     info "Getting mmcpart from U-Boot environment"
-    PART=$(fw_printenv -c /mnt/rootfs/etc/fw_env.config mmcpart | sed 's/.*=//') || PART=""
+    PART=$(fw_printenv -c "$ROOTFS_ENV_CFG" mmcpart | sed 's/.*=//') || PART=""
 
     case "$PART" in
         2)
@@ -1335,8 +1338,8 @@ elif flag_set factoryreset; then
 fi
 
 info "Switching to new rootfs"
-fw_setenv -c /mnt/rootfs/etc/fw_env.config mmcpart "$PART"
-fw_setenv -c /mnt/rootfs/etc/fw_env.config upgrade_available 1
+fw_setenv -c "$ROOTFS_ENV_CFG" mmcpart "$PART"
+fw_setenv -c "$ROOTFS_ENV_CFG" upgrade_available 1
 
 info "Done!"
 rm_fit

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -700,7 +700,7 @@ check_compatible() {
 
 select_new_partition() {
     info "Getting mmcpart from U-Boot environment"
-    PART=$(fw_printenv mmcpart | sed 's/.*=//') || PART=""
+    PART=$(fw_printenv -c /mnt/rootfs/etc/fw_env.config mmcpart | sed 's/.*=//') || PART=""
 
     case "$PART" in
         2)
@@ -1335,8 +1335,8 @@ elif flag_set factoryreset; then
 fi
 
 info "Switching to new rootfs"
-fw_setenv mmcpart "$PART"
-fw_setenv upgrade_available 1
+fw_setenv -c /mnt/rootfs/etc/fw_env.config mmcpart "$PART"
+fw_setenv -c /mnt/rootfs/etc/fw_env.config upgrade_available 1
 
 info "Done!"
 rm_fit

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -700,7 +700,7 @@ check_compatible() {
 
 select_new_partition() {
     info "Getting mmcpart from U-Boot environment"
-    PART=$(fw_printenv -c /mnt/rootfs/etc/fw_env.config mmcpart | sed 's/.*=//') || PART=""
+    PART=$(fw_printenv mmcpart | sed 's/.*=//') || PART=""
 
     case "$PART" in
         2)
@@ -1211,6 +1211,7 @@ maybe_factory_reset() {
             mount --bind /mnt/rootfs/mnt/data /mnt/data || true
         fi
 
+        cp /mnt/rootfs/etc/fw_env.config /etc/fw_env.config || true
         rm -rf /tmp/empty && mkdir /tmp/empty
 
         local cmd=(rsync -a --delete --exclude="/.wb-restore/" --exclude="/.wb-update/" /tmp/empty/ /mnt/data/)
@@ -1335,8 +1336,8 @@ elif flag_set factoryreset; then
 fi
 
 info "Switching to new rootfs"
-fw_setenv -c /mnt/rootfs/etc/fw_env.config mmcpart "$PART"
-fw_setenv -c /mnt/rootfs/etc/fw_env.config upgrade_available 1
+fw_setenv mmcpart "$PART"
+fw_setenv upgrade_available 1
 
 info "Done!"
 rm_fit

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -1205,19 +1205,13 @@ maybe_factory_reset() {
         mkdir -p /mnt/data
         if [[ -b "$DATA_PART" ]]; then
             mount -t auto "$DATA_PART" /mnt/data 2>/dev/null || true
-            info "bla"
         else
             mkdir -p /mnt/rootfs
             mount -t auto "$ROOT_PART" /mnt/rootfs || true
             mount --bind /mnt/rootfs/mnt/data /mnt/data || true
-            info "foo"
         fi
 
-        ls -la /mnt/
-
         cp /mnt/rootfs/etc/fw_env.config /etc/fw_env.config || true
-        cat /etc/fw_env.config
-
         rm -rf /tmp/empty && mkdir /tmp/empty
 
         local cmd=(rsync -a --delete --exclude="/.wb-restore/" --exclude="/.wb-update/" /tmp/empty/ /mnt/data/)

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -1336,8 +1336,6 @@ elif flag_set factoryreset; then
 fi
 
 info "Switching to new rootfs"
-info "$(cat /etc/fw_env.config)"
-cp $MNT/etc/fw_env.config /etc/fw_env.config
 fw_setenv mmcpart "$PART"
 fw_setenv upgrade_available 1
 

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -1336,6 +1336,7 @@ elif flag_set factoryreset; then
 fi
 
 info "Switching to new rootfs"
+cp $MNT/etc/fw_env.config /etc/fw_env.config
 fw_setenv mmcpart "$PART"
 fw_setenv upgrade_available 1
 

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -16,9 +16,6 @@ EXT_ROOTFS_PART=${ROOTDEV}p2
 EXT_SWAP_PART=${ROOTDEV}p3
 EXT_RESERVED_PART=${ROOTDEV}p4
 
-# U-Boot ENV tools config in mounted rootfs
-ROOTFS_ENV_CONF="/mnt/rootfs/etc/fw_env.config"
-
 # appends a command to a trap
 #
 # - 1st arg:  code to add
@@ -703,7 +700,7 @@ check_compatible() {
 
 select_new_partition() {
     info "Getting mmcpart from U-Boot environment"
-    PART=$(fw_printenv -c "$ROOTFS_ENV_CFG" mmcpart | sed 's/.*=//') || PART=""
+    PART=$(fw_printenv -c /mnt/rootfs/etc/fw_env.config mmcpart | sed 's/.*=//') || PART=""
 
     case "$PART" in
         2)
@@ -1338,8 +1335,8 @@ elif flag_set factoryreset; then
 fi
 
 info "Switching to new rootfs"
-fw_setenv -c "$ROOTFS_ENV_CFG" mmcpart "$PART"
-fw_setenv -c "$ROOTFS_ENV_CFG" upgrade_available 1
+fw_setenv -c /mnt/rootfs/etc/fw_env.config mmcpart "$PART"
+fw_setenv -c /mnt/rootfs/etc/fw_env.config upgrade_available 1
 
 info "Done!"
 rm_fit

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -1212,7 +1212,9 @@ maybe_factory_reset() {
             mount --bind /mnt/rootfs/mnt/data /mnt/data || true
         fi
 
-        # use current rootfs fw_env.config for u-boot update routines (move env data)
+        # We need uenv config in bootlet (we booted up from) to be consistent with actual running uboot binary to perform getenv/setenv operations. Typical routines:
+        # 1) *updating* => booted up with uboot binary as in-rootfs one => uboot-install-wb placed actual uenv config => copying uenv config from rootfs
+        # 2) *updating* => booted up with uboot binary different from in-rootfs one (no u-boot-install-wb performed in rootfs) => old uenv config is still in rootfs => copying
         cp /mnt/rootfs/etc/fw_env.config /etc/fw_env.config || true
 
         rm -rf /tmp/empty && mkdir /tmp/empty

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -1202,16 +1202,19 @@ maybe_factory_reset() {
     if flag_set from-initramfs; then
         info "Wiping data partition (factory reset)"
 
+        mkdir -p /mnt/rootfs
+        mount -t auto "$ROOTFS1_PART" /mnt/rootfs || true
+
         mkdir -p /mnt/data
         if [[ -b "$DATA_PART" ]]; then
             mount -t auto "$DATA_PART" /mnt/data 2>/dev/null || true
         else
-            mkdir -p /mnt/rootfs
-            mount -t auto "$ROOT_PART" /mnt/rootfs || true
             mount --bind /mnt/rootfs/mnt/data /mnt/data || true
         fi
 
+        # use current rootfs fw_env.config for u-boot update routines (move env data)
         cp /mnt/rootfs/etc/fw_env.config /etc/fw_env.config || true
+
         rm -rf /tmp/empty && mkdir /tmp/empty
 
         local cmd=(rsync -a --delete --exclude="/.wb-restore/" --exclude="/.wb-update/" /tmp/empty/ /mnt/data/)

--- a/utils/lib/wb-image-update/postinst/10update-u-boot
+++ b/utils/lib/wb-image-update/postinst/10update-u-boot
@@ -30,6 +30,7 @@ fi
 if [ -e "$ROOTFS/usr/bin/u-boot-install-wb" ] ; then
     echo "Trying to install u-boot using u-boot-install-wb from new rootfs"
     chroot "$ROOTFS" /usr/bin/u-boot-install-wb --force
+    cp $ROOTFS/etc/fw_env.config /etc/fw_env.config || true
 else
     echo "No u-boot installer found in new rootfs, skipping step"
 fi

--- a/utils/lib/wb-image-update/postinst/10update-u-boot
+++ b/utils/lib/wb-image-update/postinst/10update-u-boot
@@ -29,6 +29,7 @@ fi
 
 if [ -e "$ROOTFS/usr/bin/u-boot-install-wb" ] ; then
     echo "Trying to install u-boot using u-boot-install-wb from new rootfs"
+    cp /etc/fw_env.config $ROOTFS/etc/fw_env.config
     chroot "$ROOTFS" /usr/bin/u-boot-install-wb --force
     cp $ROOTFS/etc/fw_env.config /etc/fw_env.config || true
 else

--- a/utils/lib/wb-image-update/postinst/10update-u-boot
+++ b/utils/lib/wb-image-update/postinst/10update-u-boot
@@ -30,7 +30,7 @@ fi
 if [ -e "$ROOTFS/usr/bin/u-boot-install-wb" ] ; then
     echo "Trying to install u-boot using u-boot-install-wb from new rootfs"
     chroot "$ROOTFS" /usr/bin/u-boot-install-wb --force
-    cp $ROOTFS/etc/fw_env.config /etc/fw_env.config || true
+    cp $ROOTFS/etc/fw_env.config /etc/fw_env.config
 else
     echo "No u-boot installer found in new rootfs, skipping step"
 fi

--- a/utils/lib/wb-image-update/postinst/10update-u-boot
+++ b/utils/lib/wb-image-update/postinst/10update-u-boot
@@ -30,7 +30,7 @@ fi
 if [ -e "$ROOTFS/usr/bin/u-boot-install-wb" ] ; then
     echo "Trying to install u-boot using u-boot-install-wb from new rootfs"
     chroot "$ROOTFS" /usr/bin/u-boot-install-wb --force
-    cp $ROOTFS/etc/fw_env.config /etc/fw_env.config
+    cp $ROOTFS/etc/fw_env.config /etc/fw_env.config || true
 else
     echo "No u-boot installer found in new rootfs, skipping step"
 fi

--- a/utils/lib/wb-image-update/postinst/10update-u-boot
+++ b/utils/lib/wb-image-update/postinst/10update-u-boot
@@ -32,6 +32,9 @@ if [ -e "$ROOTFS/usr/bin/u-boot-install-wb" ] ; then
     cp /etc/fw_env.config $ROOTFS/etc/fw_env.config
     chroot "$ROOTFS" /usr/bin/u-boot-install-wb --force
     cp $ROOTFS/etc/fw_env.config /etc/fw_env.config || true
+    if [ -f "/tmp/fw_env.txt" ]; then
+        mv /tmp/fw_env.txt /mnt/data/.wb-restore/
+    fi
 else
     echo "No u-boot installer found in new rootfs, skipping step"
 fi


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Ребейзим наши патчи убута на новую версию, новый убут занимает больше места и наезжает на область хранения енвов на wb7, поэтому енвы нужно хранить в другом месте.

___________________________________
**Что поменялось для пользователей:**
Добавлен новый флаг совместимости `uboot-dynamic-env` и патчи для копирования fw_env.config из актуальной rootfs, а так же в новую rootfs и обратно, чтобы в окружении скриптов всегда были правильные данные о местоположении енвов убута.

___________________________________
**Как проверял/а:**
По чеклисту проверок нового убута.

