### PR TITLE
Improve modem restart

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.27.4) stable; urgency=medium
+
+  * Add modem restart if it is in attached state, but supported IP families info is missing
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Sat, 10 Jan 2026 16:38:52 +0500
+
 wb-utils (4.27.3) stable; urgency=medium
 
   * Bump version, no functional changes

--- a/utils/bin/wb-gsm-mm
+++ b/utils/bin/wb-gsm-mm
@@ -10,6 +10,24 @@ reattach_modem_if_needed() {
     fi
 }
 
+check_restart_modem_needed() {
+    modem_info=$(mmcli -m wbc -K)
+    
+    # Getting supported IP families fails, but modem is in registered state and GPRS is attached
+    # It is an invalid state, so we need to restart the modem 
+    if echo "$modem_info" | grep -qE "modem\.generic\.state.*registered" && \
+       echo "$modem_info" | grep -q "modem\.3gpp\.packet-service-state.*attached";
+    then
+        if ! echo "$modem_info" | grep -q "modem\.generic\.supported-ip-families"; then
+            return 0
+        fi
+        if echo "$modem_info" | grep -q "modem\.generic\.supported-ip-families\.length.*: 0"; then
+            return 0
+        fi
+    fi
+    return 1
+}
+
 watchdog() {
     sleep $(($WATCHDOG_USEC / 6000000))
     while true; do
@@ -19,6 +37,9 @@ watchdog() {
                 if [ $? -ne 0 ] && [ "$output" = "error: couldn't find modem" ]; then
                     echo "ModemManager is running, but modem is not found"
                 else
+                    if check_restart_modem_needed; then
+                        exit 1
+                    fi
                     systemd-notify WATCHDOG=1
                     reattach_modem_if_needed
                 fi


### PR DESCRIPTION
Add if modem is in attached state, but supported IP families info is missing. NetworkManager can't create connection without the information

___________________________________
**Что происходит; кому и зачем нужно:**

Иногда ModemManager не может получить данные о поддерживаемых типах IP соединений. В такой ситуации NM не может создать соединение.

```
06-01-2026 23:49:29.105 	<info>  [1767725369.1030] manager: NetworkManager state is now DISCONNECTED
06-01-2026 23:49:29.102 	<info>  [1767725369.1018] device (ttyUSB1): state change: prepare -> failed (reason 'modem-init-failed', sys-iface-state: 'managed')
06-01-2026 23:49:29.100 	<warn>  [1767725369.0989] modem-broadband[ttyUSB1]: failed to connect 'wb-gsm-sim1': Connection requested IPv4 but IPv4 is unsupported by the modem.
06-01-2026 23:49:29.098 	<info>  [1767725369.0980] manager: NetworkManager state is now CONNECTING
```

Перезапускаем модем, чтобы MM переинициализировал его.
Наблюдаю такое поведение, при ограничении интернета при угрозе беспилотной опасности. Отладить MM не могу, т.к. это бывает очень редко.

___________________________________
**Что поменялось для пользователей:**

Соединение восстанавливается.

___________________________________
**Как проверял/а:**


