### PR TITLE
Fix warning on package upgrade

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.27.5) stable; urgency=medium
+
+  * Fix warning on package upgrade
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 21 Jan 2026 17:20:00 +0400
+
 wb-utils (4.27.4) stable; urgency=medium
 
   * Add modem restart if it is in attached state, but supported IP families info is missing

--- a/debian/rules
+++ b/debian/rules
@@ -17,7 +17,7 @@ override_dh_systemd_enable:
 	dh_systemd_enable --name=wb-usb-otg wb-usb-otg.service
 
 override_dh_systemd_start:
-	dh_systemd_start --name=wb-prepare --no-start wb-prepare.service
+	dh_systemd_start --name=wb-prepare --no-start --no-restart-after-upgrade --no-restart-on-upgrade wb-prepare.service
 	dh_systemd_start --name=wb-init --no-start wb-init.service
 	dh_systemd_start --name=wb-watch-update --restart-after-upgrade wb-watch-update.service
 	dh_systemd_start --name=wb-gsm wb-gsm.service


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
При каждом обновлении wb-utils возникает:
```sh
Failed to try-restart wb-prepare.service: Operation refused, unit wb-prepare.service may be requested by dependency only (it is configured to refuse manual start/stop).
See system logs and 'systemctl status wb-prepare.service' for details.
```
Не критично, но некрасиво.

Изменение в сгенеренном postinst:
```diff
--- DEBIAN.old/postinst	2026-01-21 17:35:00.000000000 +0400
+++ DEBIAN.new/postinst	2026-01-21 17:35:00.000000000 +0400
@@ -90,16 +90,6 @@
 	if [ -d /run/systemd/system ]; then
 		systemctl --system daemon-reload >/dev/null || true
 		if [ -n "$2" ]; then
-			deb-systemd-invoke try-restart 'wb-prepare.service' >/dev/null || true
-		fi
-	fi
-fi
-# End automatically added section
-# Automatically added by dh_systemd_start/13.3.4
-if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
-	if [ -d /run/systemd/system ]; then
-		systemctl --system daemon-reload >/dev/null || true
-		if [ -n "$2" ]; then
 			deb-systemd-invoke try-restart 'wb-init.service' >/dev/null || true
 		fi
 	fi
```

___________________________________
**Что поменялось для пользователей:**
Нет ворнинга при обновлении

___________________________________
**Как проверял/а:**
на вб
