### PR TITLE
Don't wipe /mnt/data during upgrade with fit-image

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-utils (4.28.2) stable; urgency=medium
+
+  * Don't wipe /mnt/data during upgrade with fit-image
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 05 Jun 2026 16:20:00 +0400
+
 wb-utils (4.28.1) stable; urgency=medium
 
   * Don't allow rollback from trixie to bullseye without factoryreset

--- a/utils/lib/wb-image-update/fit/install_update.sh
+++ b/utils/lib/wb-image-update/fit/install_update.sh
@@ -693,7 +693,7 @@ cleanup_rootfs() {
 
     if which rsync >/dev/null; then
         info "Cleaning up using rsync"
-        cmd=(rsync -a --delete --exclude="/mnt/data/.wb-restore/" --exclude="/mnt/data/.wb-update/" /tmp/empty/ "$mountpoint")
+        cmd=(rsync -a --delete --exclude="/mnt/data/" /tmp/empty/ "$mountpoint")
     else
         info "Can't find rsync, cleaning up using rm -rf (may be slower)"
         cmd=(rm -rf "$mountpoint"/..?* "$mountpoint"/.[!.]* "${mountpoint:?}"/*)


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
На расширеной рутфс при обновлении фитом без FR очищалось /mnt/data как при FR

___________________________________
**Что поменялось для пользователей:**
ничего, до массового пользователя еще не доехало

___________________________________
**Как проверял/а:**
проверил обновление фитом с FR и без FR

